### PR TITLE
Add code highlight widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- feat: add FlutterDeckCodeHighlight widget
+
 # 0.1.0+3
 
 - docs: extend README.md with more information, code snippets and presentation examples

--- a/README.md
+++ b/README.md
@@ -316,6 +316,54 @@ class FlutterDeckBulletListDemoSlide extends FlutterDeckSplitSlide {
 }
 ```
 
+### FlutterDeckCodeHighlight
+
+Provides a widget that gives you customizable syntax highlighting for many languages.
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_deck/flutter_deck.dart';
+
+class CodeHighlightSlide extends FlutterDeckBlankSlide {
+  const CodeHighlightSlide({
+    super.key,
+  }) : super(
+          configuration: const FlutterDeckSlideConfiguration(
+            route: '/code-highlight',
+            header: FlutterDeckHeaderConfiguration(
+              title: 'Code Highlighting',
+            ),
+          ),
+        );
+
+  @override
+  Widget body(BuildContext context) => const Center(
+        child: FlutterDeckCodeHighlight(
+          code: '''
+import 'package:flutter_deck/flutter_deck.dart';
+
+class TitleSlide extends FlutterDeckTitleSlide {
+  const TitleSlide({super.key})
+      : super(
+          configuration: const FlutterDeckSlideConfiguration(
+            route: '/intro',
+            footer: FlutterDeckFooterConfiguration(showFooter: false),
+          ),
+        );
+
+  @override
+  String get title => 'Welcome to flutter_deck example! 🚀';
+
+  @override
+  String? get subtitle => 'Use left and right arrow keys to navigate.';
+}''',
+          fileName: 'title_slide.dart',
+          language: 'dart',
+        ),
+      );
+}
+```
+
 ## Accessing slide deck state from the code
 
 By using the `FlutterDeck` extensions, you can access the slide deck state and its methods from anywhere in the app:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,7 @@ class FlutterDeckExample extends StatelessWidget {
         TransitionsSlide(),
         DrawerSlide(),
         StepsSlide(),
+        CodeHighlightSlide(),
         EndSlide(),
       ],
       // Introduce yourself!

--- a/example/lib/slides/code_highlight_slide.dart
+++ b/example/lib/slides/code_highlight_slide.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_deck/flutter_deck.dart';
+
+class CodeHighlightSlide extends FlutterDeckBlankSlide {
+  const CodeHighlightSlide({
+    super.key,
+  }) : super(
+          configuration: const FlutterDeckSlideConfiguration(
+            route: '/code-highlight',
+            header: FlutterDeckHeaderConfiguration(
+              title: 'Code Highlighting',
+            ),
+          ),
+        );
+
+  @override
+  Widget body(BuildContext context) => const Center(
+        child: FlutterDeckCodeHighlight(
+          code: '''
+import 'package:flutter_deck/flutter_deck.dart';
+
+class TitleSlide extends FlutterDeckTitleSlide {
+  const TitleSlide({super.key})
+      : super(
+          configuration: const FlutterDeckSlideConfiguration(
+            route: '/intro',
+            footer: FlutterDeckFooterConfiguration(showFooter: false),
+          ),
+        );
+
+  @override
+  String get title => 'Welcome to flutter_deck example! 🚀';
+
+  @override
+  String? get subtitle => 'Use left and right arrow keys to navigate.';
+}''',
+          fileName: 'title_slide.dart',
+          language: 'dart',
+        ),
+      );
+}

--- a/example/lib/slides/slides.dart
+++ b/example/lib/slides/slides.dart
@@ -1,4 +1,5 @@
 export 'blank_slide.dart';
+export 'code_highlight_slide.dart';
 export 'drawer_slide.dart';
 export 'end_slide.dart';
 export 'image_slide.dart';

--- a/lib/src/widgets/flutter_deck_code_highlight.dart
+++ b/lib/src/widgets/flutter_deck_code_highlight.dart
@@ -6,41 +6,76 @@ import 'package:flutter_highlight/themes/vs2015.dart';
 /// This widget provides syntax highlighting for many languages.
 class FlutterDeckCodeHighlight extends StatelessWidget {
   /// Creates a syntax highlighting widget for displaying code.
+  ///
+  /// Will use [vs2015Theme] for dark theme and [defaultTheme] for light theme.
+  ///
+  /// For a list of all available [language] values, see:
+  /// https://github.com/git-touch/highlight.dart/tree/master/highlight/lib/languages
+  ///
+  /// For a list of all available [darkTextStyles] and [lightTextStyles]
+  /// values, see:
+  /// https://github.com/git-touch/highlight.dart/tree/master/flutter_highlight/lib/themes
+  ///
+  /// [textStyle] will be merged with all theme text styles.
+  ///
+  /// Use [darkTextStyles] and [lightTextStyles] to provide or override the
+  /// whole theme.
   const FlutterDeckCodeHighlight({
     required String code,
     super.key,
+    Map<String, TextStyle>? darkTextStyles,
     String? fileName,
     String language = 'dart',
+    Map<String, TextStyle>? lightTextStyles,
+    TextStyle? textStyle,
   })  : _code = code,
+        _darkTextStyles = darkTextStyles,
         _fileName = fileName,
-        _language = language;
+        _language = language,
+        _lightTextStyles = lightTextStyles,
+        _textStyle = textStyle;
+
   final String _code;
+  final Map<String, TextStyle>? _darkTextStyles;
   final String? _fileName;
   final String _language;
+  final Map<String, TextStyle>? _lightTextStyles;
+  final TextStyle? _textStyle;
 
   @override
-  Widget build(BuildContext context) => DecoratedBox(
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.background,
-          borderRadius: const BorderRadius.all(Radius.circular(16)),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (_fileName != null) Text(_fileName!),
-              HighlightView(
-                _code,
-                language: _language,
-                padding: const EdgeInsets.all(16),
-                theme: Theme.of(context).brightness == Brightness.dark
-                    ? vs2015Theme
-                    : defaultTheme,
-              ),
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.background,
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (_fileName != null) ...[
+              Text(_fileName!),
+              const SizedBox(height: 4),
             ],
-          ),
+            HighlightView(
+              _code,
+              language: _language,
+              padding: const EdgeInsets.all(16),
+              theme: (Theme.of(context).brightness == Brightness.dark
+                      ? _darkTextStyles ?? vs2015Theme
+                      : _lightTextStyles ?? defaultTheme)
+                  .map(
+                (key, value) => MapEntry(
+                  key,
+                  value.merge(_textStyle),
+                ),
+              ),
+            ),
+          ],
         ),
-      );
+      ),
+    );
+  }
 }

--- a/lib/src/widgets/flutter_deck_code_highlight.dart
+++ b/lib/src/widgets/flutter_deck_code_highlight.dart
@@ -12,34 +12,22 @@ class FlutterDeckCodeHighlight extends StatelessWidget {
   /// For a list of all available [language] values, see:
   /// https://github.com/git-touch/highlight.dart/tree/master/highlight/lib/languages
   ///
-  /// For a list of all available [darkTextStyles] and [lightTextStyles]
-  /// values, see:
-  /// https://github.com/git-touch/highlight.dart/tree/master/flutter_highlight/lib/themes
-  ///
-  /// [textStyle] will be merged with all theme text styles.
-  ///
-  /// Use [darkTextStyles] and [lightTextStyles] to provide or override the
-  /// whole theme.
+  /// Use [textStyle] to set custom font size and other text style properties
+  /// for the root theme.
   const FlutterDeckCodeHighlight({
     required String code,
     super.key,
-    Map<String, TextStyle>? darkTextStyles,
     String? fileName,
     String language = 'dart',
-    Map<String, TextStyle>? lightTextStyles,
     TextStyle? textStyle,
   })  : _code = code,
-        _darkTextStyles = darkTextStyles,
         _fileName = fileName,
         _language = language,
-        _lightTextStyles = lightTextStyles,
         _textStyle = textStyle;
 
   final String _code;
-  final Map<String, TextStyle>? _darkTextStyles;
   final String? _fileName;
   final String _language;
-  final Map<String, TextStyle>? _lightTextStyles;
   final TextStyle? _textStyle;
 
   @override
@@ -56,22 +44,20 @@ class FlutterDeckCodeHighlight extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (_fileName != null) ...[
-              Text(_fileName!),
+              Text(
+                _fileName!,
+                style: _textStyle,
+              ),
               const SizedBox(height: 4),
             ],
             HighlightView(
               _code,
               language: _language,
               padding: const EdgeInsets.all(16),
-              theme: (Theme.of(context).brightness == Brightness.dark
-                      ? _darkTextStyles ?? vs2015Theme
-                      : _lightTextStyles ?? defaultTheme)
-                  .map(
-                (key, value) => MapEntry(
-                  key,
-                  value.merge(_textStyle),
-                ),
-              ),
+              textStyle: _textStyle,
+              theme: Theme.of(context).brightness == Brightness.dark
+                  ? vs2015Theme
+                  : defaultTheme,
             ),
           ],
         ),

--- a/lib/src/widgets/flutter_deck_code_highlight.dart
+++ b/lib/src/widgets/flutter_deck_code_highlight.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/themes/default.dart';
+import 'package:flutter_highlight/themes/vs2015.dart';
+
+/// This widget provides syntax highlighting for many languages.
+class FlutterDeckCodeHighlight extends StatelessWidget {
+  /// Creates a syntax highlighting widget for displaying code.
+  const FlutterDeckCodeHighlight({
+    required String code,
+    super.key,
+    String? fileName,
+    String language = 'dart',
+  })  : _code = code,
+        _fileName = fileName,
+        _language = language;
+  final String _code;
+  final String? _fileName;
+  final String _language;
+
+  @override
+  Widget build(BuildContext context) => DecoratedBox(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.background,
+          borderRadius: const BorderRadius.all(Radius.circular(16)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (_fileName != null) Text(_fileName!),
+              HighlightView(
+                _code,
+                language: _language,
+                padding: const EdgeInsets.all(16),
+                theme: Theme.of(context).brightness == Brightness.dark
+                    ? vs2015Theme
+                    : defaultTheme,
+              ),
+            ],
+          ),
+        ),
+      );
+}

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -1,4 +1,5 @@
 export 'flutter_deck_bullet_list.dart';
+export 'flutter_deck_code_highlight.dart';
 export 'flutter_deck_footer.dart';
 export 'flutter_deck_header.dart';
 export 'flutter_deck_slide_steps_builder.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   auto_size_text: ^3.0.0
   flutter:
     sdk: flutter
+  flutter_highlight: ^0.7.0
   go_router: ^10.0.0
 
 dev_dependencies:


### PR DESCRIPTION
I started something similar right after FlutterCon. And I implemented one specific widget that I found necessary for slides: the code highlight widget. It uses `flutter_highlight`.

## Status

**READY**

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
