### PR TITLE
fix: fix drawer toggle code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- fix: drawer toggle
+
 # 0.1.0+3
 
 - docs: extend README.md with more information, code snippets and presentation examples

--- a/lib/src/flutter_deck_slide.dart
+++ b/lib/src/flutter_deck_slide.dart
@@ -60,9 +60,11 @@ class _SlideBody extends StatelessWidget {
     final scaffoldState = Scaffold.of(context);
 
     return FlutterDeckDrawerListener(
-      onDrawerToggle: scaffoldState.isDrawerOpen
-          ? scaffoldState.closeDrawer
-          : scaffoldState.openDrawer,
+      onDrawerToggle: () {
+        scaffoldState.isDrawerOpen
+            ? scaffoldState.closeDrawer()
+            : scaffoldState.openDrawer();
+      },
       child: child,
     );
   }


### PR DESCRIPTION
## Status

**READY**

## Description

The drawer toggle only works the first time that it is being used. After that, the drawer will not close or open again by pressing the key.
The issue is caused by providing only tear-offs. These are only evaluated once and then never again. It has to be an actual callback method that is evaluated/executed every time the change notifier fires.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
