### PR TITLE
fix: override text colors for Material text styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1
+
+fix: override text colors for Material text styles
+
 # 0.4.0
 
 - **BREAKING**: refactor: rework the way how a new slide is created

--- a/lib/src/flutter_deck_slide.dart
+++ b/lib/src/flutter_deck_slide.dart
@@ -252,17 +252,29 @@ class FlutterDeckSlide extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final materialTheme = Theme.of(context);
     final theme = FlutterDeckTheme.of(context).merge(_theme);
-    final slideTheme = theme.slideTheme;
-    final textTheme = theme.textTheme;
 
-    return FlutterDeckTheme(
-      data: theme.copyWith(textTheme: textTheme.apply(color: slideTheme.color)),
-      child: Builder(
-        builder: (context) => Scaffold(
-          backgroundColor: slideTheme.backgroundColor,
-          drawer: const FlutterDeckDrawer(),
-          body: _SlideBody(child: _builder(context)),
+    final slideTheme = theme.slideTheme;
+    final backgroundColor = slideTheme.backgroundColor;
+    final color = slideTheme.color;
+
+    return Theme(
+      data: materialTheme.copyWith(
+        textTheme: materialTheme.textTheme.apply(
+          bodyColor: color,
+          displayColor: color,
+          decorationColor: color,
+        ),
+      ),
+      child: FlutterDeckTheme(
+        data: theme.copyWith(textTheme: theme.textTheme.apply(color: color)),
+        child: Builder(
+          builder: (context) => Scaffold(
+            backgroundColor: backgroundColor,
+            drawer: const FlutterDeckDrawer(),
+            body: _SlideBody(child: _builder(context)),
+          ),
         ),
       ),
     );

--- a/lib/src/templates/split_slide.dart
+++ b/lib/src/templates/split_slide.dart
@@ -172,16 +172,26 @@ class _ContentSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final materialTheme = Theme.of(context);
     final theme = FlutterDeckTheme.of(context);
 
-    return FlutterDeckTheme(
-      data: theme.copyWith(textTheme: theme.textTheme.apply(color: color)),
-      child: Builder(
-        builder: (context) => Expanded(
-          flex: flex,
-          child: Padding(
-            padding: FlutterDeckLayout.slidePadding,
-            child: builder(context),
+    return Theme(
+      data: materialTheme.copyWith(
+        textTheme: materialTheme.textTheme.apply(
+          bodyColor: color,
+          displayColor: color,
+          decorationColor: color,
+        ),
+      ),
+      child: FlutterDeckTheme(
+        data: theme.copyWith(textTheme: theme.textTheme.apply(color: color)),
+        child: Builder(
+          builder: (context) => Expanded(
+            flex: flex,
+            child: Padding(
+              padding: FlutterDeckLayout.slidePadding,
+              child: builder(context),
+            ),
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_deck
 description: A lightweight, customizable, and easy-to-use framework to create presentations in Flutter.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/mkobuolys/flutter_deck
 repository: https://github.com/mkobuolys/flutter_deck
 issue_tracker: https://github.com/mkobuolys/flutter_deck/issues


### PR DESCRIPTION
## Description

Fixed the Material text style colour issues for the split slide template.

Partially fixes https://github.com/mkobuolys/flutter_deck/issues/12

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
