### PR TITLE
feat: add FlutterDeckAspectRatio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # NEXT
 
+- feat: add `FlutterDeckAspectRatio` to set the aspect ratio for the whole slide deck
 - ci: update the example's base url for GitHub Pages deployment
 
 # 0.8.0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Also, you can define a global configuration for your slide deck:
 ```dart
 FlutterDeckApp(
   configuration: const FlutterDeckConfiguration(
+    aspectRatio: FlutterDeckAspectRatio.ratio16x9(),
     background: FlutterDeckBackgroundConfiguration(
       light: FlutterDeckBackground.solid(Color(0xFFB5FFFC)),
       dark: FlutterDeckBackground.solid(Color(0xFF16222A)),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,8 @@ class FlutterDeckExample extends StatelessWidget {
     return FlutterDeckApp(
       // You could use the default configuration or create your own.
       configuration: const FlutterDeckConfiguration(
+        // Set the aspect ratio of the deck.
+        aspectRatio: FlutterDeckAspectRatio.ratio16x9(),
         // Define a global background for the light and dark themes separately.
         background: FlutterDeckBackgroundConfiguration(
           light: FlutterDeckBackground.gradient(

--- a/lib/flutter_deck.dart
+++ b/lib/flutter_deck.dart
@@ -3,6 +3,7 @@ library flutter_deck;
 
 export 'src/flutter_deck.dart';
 export 'src/flutter_deck_app.dart';
+export 'src/flutter_deck_aspect_ratio.dart';
 export 'src/flutter_deck_configuration.dart';
 export 'src/flutter_deck_slide.dart';
 export 'src/flutter_deck_speaker_info.dart';

--- a/lib/src/flutter_deck_aspect_ratio.dart
+++ b/lib/src/flutter_deck_aspect_ratio.dart
@@ -1,0 +1,50 @@
+/// The aspect ratio of the deck.
+///
+/// The aspect ratio is expressed as a ratio of width to height. For example,
+/// an aspect ratio of 16:9 means the deck's width is 16/9 times its height.
+///
+/// If you do not want to constrain the deck's aspect ratio and leave it
+/// responsive, use [FlutterDeckAspectRatio.responsive].
+///
+/// See also:
+///
+/// * [FlutterDeckAspectRatio.custom], which creates a custom aspect ratio.
+/// * [FlutterDeckAspectRatio.ratio4x3], which creates a 4:3 aspect ratio.
+/// * [FlutterDeckAspectRatio.ratio16x9], which creates a 16:9 aspect ratio.
+/// * [FlutterDeckAspectRatio.ratio16x10], which creates a 16:10 aspect ratio.
+/// * [FlutterDeckAspectRatio.responsive], which does not constrain the aspect
+/// ratio of the deck and leaves it responsive to the size of the screen.
+class FlutterDeckAspectRatio {
+  /// Creates an aspect ratio for the deck.
+  ///
+  /// This constructor is private and should not be used directly. Instead, use
+  /// one of the named constructors to define an aspect ratio.
+  const FlutterDeckAspectRatio._([this._aspectRatio]);
+
+  /// Creates a custom aspect ratio for the deck.
+  ///
+  /// [aspectRatio] is the ratio of width to height. For example, if you want
+  /// the deck to have an aspect ratio of 16:9, pass in 16/9.
+  const FlutterDeckAspectRatio.custom(double aspectRatio) : this._(aspectRatio);
+
+  /// Creates a 4:3 aspect ratio for the deck.
+  const FlutterDeckAspectRatio.ratio4x3() : this._(4 / 3);
+
+  /// Creates a 16:9 aspect ratio for the deck.
+  const FlutterDeckAspectRatio.ratio16x9() : this._(16 / 9);
+
+  /// Creates a 16:10 aspect ratio for the deck.
+  const FlutterDeckAspectRatio.ratio16x10() : this._(16 / 10);
+
+  /// Creates a responsive aspect ratio for the deck. This means the aspect
+  /// ratio is not constrained and will be responsive to the size of the screen.
+  ///
+  /// This is the default aspect ratio for the deck.
+  const FlutterDeckAspectRatio.responsive() : this._();
+
+  /// The aspect ratio of the deck.
+  final double? _aspectRatio;
+
+  /// Returns the aspect ratio value of the deck.
+  double? get value => _aspectRatio;
+}

--- a/lib/src/flutter_deck_configuration.dart
+++ b/lib/src/flutter_deck_configuration.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_deck/src/flutter_deck_aspect_ratio.dart';
 import 'package:flutter_deck/src/flutter_deck_slide.dart';
 import 'package:flutter_deck/src/templates/templates.dart';
 import 'package:flutter_deck/src/theme/templates/flutter_deck_slide_theme.dart';
@@ -13,6 +14,7 @@ import 'package:flutter_deck/src/widgets/widgets.dart';
 class FlutterDeckConfiguration {
   /// Creates a global configuration for the slide deck.
   const FlutterDeckConfiguration({
+    this.aspectRatio = const FlutterDeckAspectRatio.responsive(),
     this.background = const FlutterDeckBackgroundConfiguration(),
     this.controls = const FlutterDeckControlsConfiguration(),
     this.footer = const FlutterDeckFooterConfiguration(showFooter: false),
@@ -22,6 +24,15 @@ class FlutterDeckConfiguration {
     this.showProgress = true,
     this.transition = const FlutterDeckTransition.none(),
   });
+
+  /// The aspect ratio of the slide deck.
+  ///
+  /// By default, the aspect ratio is [FlutterDeckAspectRatio.responsive],
+  /// which means the aspect ratio is not constrained and will be responsive to
+  /// the size of the screen.
+  ///
+  /// This configuration cannot be overridden by the slide configuration.
+  final FlutterDeckAspectRatio aspectRatio;
 
   /// The background configuration for the slide deck. By default, the
   /// background is transparent and [FlutterDeckSlideThemeData.backgroundColor]

--- a/lib/src/flutter_deck_slide.dart
+++ b/lib/src/flutter_deck_slide.dart
@@ -361,21 +361,38 @@ class _SlideBody extends StatelessWidget {
     final configuration = context.flutterDeck.configuration;
     final scaffoldState = Scaffold.of(context);
 
+    var body = configuration.showProgress
+        ? Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              child,
+              configuration.progressIndicator,
+            ],
+          )
+        : child;
+
+    final globalConfiguration = context.flutterDeck.globalConfiguration;
+    final aspectRatio = globalConfiguration.aspectRatio.value;
+
+    if (aspectRatio != null) {
+      body = ColoredBox(
+        color: Colors.black,
+        child: Center(
+          child: AspectRatio(
+            aspectRatio: aspectRatio,
+            child: body,
+          ),
+        ),
+      );
+    }
+
     return FlutterDeckDrawerListener(
       onDrawerToggle: () {
         scaffoldState.isDrawerOpen
             ? scaffoldState.closeDrawer()
             : scaffoldState.openDrawer();
       },
-      child: configuration.showProgress
-          ? Stack(
-              alignment: Alignment.bottomCenter,
-              children: [
-                child,
-                configuration.progressIndicator,
-              ],
-            )
-          : child,
+      child: body,
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a global configuration value to set the aspect ratio for the whole slide deck. By default, the value remains as `FlutterDeckAspectRatio.responsive`. It means that this change is not breaking and slides will be responsive to the size of the screen.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
