### PR TITLE
feat: navigation drawer item title is generated from the slide configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@
       )
       ```
 
+- feat: add `title` property to the `FlutterDeckSlideConfiguration`
+- feat: navigation drawer item title is generated from the slide configuration
+
 # 0.9.1
 
 - fix: adjust control widget styling and the default slide background color

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ class NewSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/new-slide',
+            title: 'New slide',
           ),
         );
 
@@ -163,6 +164,7 @@ class TitleSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/title-slide',
+            title: 'Title slide',
             footer: FlutterDeckFooterConfiguration(showFooter: false),
           ),
         );
@@ -348,6 +350,7 @@ class TemplateSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/template-slide',
+            title: 'Template slide',
           ),
         );
 
@@ -386,6 +389,7 @@ class CustomSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/custom-slide',
+            title: 'Custom slide',
           ),
         );
 
@@ -533,6 +537,7 @@ class FlutterDeckBulletListDemoSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/bullet-list-demo',
+            title: 'Bullet list demo',
             steps: 3, // Define the number of steps for the slide
           ),
         );
@@ -675,6 +680,7 @@ class TransitionsSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/transitions',
+            title: 'Transitions',
             transition: FlutterDeckTransition.rotation(), // Specify the transition for the slide
           ),
         );
@@ -713,6 +719,7 @@ class CustomTransitionSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/custom-transition',
+            title: 'Custom transition',
             transition: FlutterDeckTransition.custom(
               transitionBuilder: VerticalTransitionBuilder(),
             ),
@@ -735,6 +742,7 @@ class StepsDemoSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/steps-demo',
+            title: 'Steps demo',
             steps: 2,
           ),
         );

--- a/README.md
+++ b/README.md
@@ -776,6 +776,12 @@ Widget build(BuildContext context) {
 
 Every slide deck comes with a navigation drawer that can be used to navigate through the slide deck. The navigation drawer is automatically generated based on the slide deck configuration.
 
+The navigation drawer item title is generated based on the following rules:
+
+- The slide title is used if it is set in the slide configuration (`FlutterDeckSlideConfiguration.title`).
+- If the slide title is not set, the header title is used if it is set in the slide header configuration (`FlutterDeckHeaderConfiguration.title`).
+- The slide route is used otherwise.
+
 ![Navigation demo](https://github.com/mkobuolys/flutter_deck/blob/main/images/navigation.gif?raw=true)
 
 ## Marker tool

--- a/example/lib/slides/end_slide.dart
+++ b/example/lib/slides/end_slide.dart
@@ -6,6 +6,7 @@ class EndSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/end',
+            title: 'Thank you!',
             footer: FlutterDeckFooterConfiguration(showFooter: false),
           ),
         );

--- a/example/lib/slides/layout_structure_slide.dart
+++ b/example/lib/slides/layout_structure_slide.dart
@@ -6,6 +6,7 @@ class LayoutStructureSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/layout-structure',
+            title: 'Layout structure',
           ),
         );
 

--- a/example/lib/slides/theming_slide.dart
+++ b/example/lib/slides/theming_slide.dart
@@ -6,6 +6,7 @@ class ThemingSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/theming-slide',
+            title: 'Theming',
             header: FlutterDeckHeaderConfiguration(title: 'Theming'),
           ),
         );

--- a/example/lib/slides/title_slide.dart
+++ b/example/lib/slides/title_slide.dart
@@ -6,6 +6,7 @@ class TitleSlide extends FlutterDeckSlideWidget {
       : super(
           configuration: const FlutterDeckSlideConfiguration(
             route: '/intro',
+            title: 'Welcome to flutter_deck',
             footer: FlutterDeckFooterConfiguration(showFooter: false),
           ),
         );

--- a/lib/src/configuration/flutter_deck_configuration.dart
+++ b/lib/src/configuration/flutter_deck_configuration.dart
@@ -101,12 +101,17 @@ class FlutterDeckSlideConfiguration extends FlutterDeckConfiguration {
   ///
   /// [steps] is the number of steps in the slide. The default is 1.
   ///
+  /// [title] is the title of the slide. If the title is set, it will be used in
+  /// the navigation drawer instead of the header title (or route as a
+  /// fallback).
+  ///
   /// [footer], [header], [progressIndicator], [showProgress], and [transition]
   /// are optional overrides for the global configuration.
   const FlutterDeckSlideConfiguration({
     required this.route,
     this.hidden = false,
     this.steps = 1,
+    this.title,
     FlutterDeckFooterConfiguration? footer,
     FlutterDeckHeaderConfiguration? header,
     FlutterDeckProgressIndicator? progressIndicator,
@@ -124,6 +129,7 @@ class FlutterDeckSlideConfiguration extends FlutterDeckConfiguration {
     required this.route,
     this.hidden = false,
     this.steps = 1,
+    this.title,
     super.footer,
     super.header,
     super.progressIndicator,
@@ -137,6 +143,12 @@ class FlutterDeckSlideConfiguration extends FlutterDeckConfiguration {
 
   /// The route for the slide.
   final String route;
+
+  /// The title of the slide.
+  ///
+  /// If the title is set, it will be used in the navigation drawer instead of
+  /// the header title (or route as a fallback).
+  final String? title;
 
   /// Whether the slide is hidden or not.
   ///
@@ -164,6 +176,7 @@ class FlutterDeckSlideConfiguration extends FlutterDeckConfiguration {
       route: route,
       hidden: hidden,
       steps: steps,
+      title: title,
       footer: _footerConfigurationOverride ?? configuration.footer,
       header: _headerConfigurationOverride ?? configuration.header,
       progressIndicator:

--- a/lib/src/widgets/internal/drawer/flutter_deck_drawer.dart
+++ b/lib/src/widgets/internal/drawer/flutter_deck_drawer.dart
@@ -36,6 +36,19 @@ class _SlideCard extends StatelessWidget {
   final FlutterDeckRouterSlide slide;
   final int index;
 
+  String _getSlideTitle() {
+    final configuration = slide.configuration;
+    final title = configuration.title;
+
+    if (title != null) return title;
+
+    final header = configuration.header;
+
+    if (header.showHeader) return header.title;
+
+    return configuration.route;
+  }
+
   @override
   Widget build(BuildContext context) {
     final currentSlideNumber = context.flutterDeck.slideNumber;
@@ -45,7 +58,7 @@ class _SlideCard extends StatelessWidget {
     return ListTile(
       selected: isActive,
       leading: Text('$slideNumber.'),
-      title: Text(slide.configuration.route),
+      title: Text(_getSlideTitle()),
       onTap: () {
         if (!isActive) context.flutterDeck.goToSlide(slideNumber);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The navigation drawer item title is generated based on the following rules:

- The slide title is used if it is set in the slide configuration (`FlutterDeckSlideConfiguration.title`).
- If the slide title is not set, the header title is used if it is set in the slide header configuration (`FlutterDeckHeaderConfiguration.title`).
- The slide route is used otherwise.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
