### PR TITLE
fix: hot reload didn't work property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- fix: hot reload doesn't work on macOS
+
 # 0.11.0
 
 - feat: set scroll position to currently active slide on navigation drawer open

--- a/lib/src/flutter_deck_router.dart
+++ b/lib/src/flutter_deck_router.dart
@@ -1,8 +1,19 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck_slide.dart';
 import 'package:go_router/go_router.dart';
 
 const _queryParameterStep = 'step';
+
+class _FlutterDeckSlidePage extends StatelessWidget {
+  const _FlutterDeckSlidePage(this.slide);
+  final FlutterDeckRouterSlide slide;
+
+  @override
+  Widget build(BuildContext context) {
+    return slide.widget.build(context);
+  }
+}
 
 /// A slide route for the slide deck.
 class FlutterDeckRouterSlide {
@@ -63,7 +74,7 @@ class FlutterDeckRouter {
               key: state.pageKey,
               restorationId: state.pageKey.value,
               transitionsBuilder: slide.configuration.transition.build,
-              child: slide.widget.build(context),
+              child: _FlutterDeckSlidePage(slide),
             ),
           ),
       ],

--- a/lib/src/flutter_deck_router.dart
+++ b/lib/src/flutter_deck_router.dart
@@ -5,16 +5,6 @@ import 'package:go_router/go_router.dart';
 
 const _queryParameterStep = 'step';
 
-class _FlutterDeckSlidePage extends StatelessWidget {
-  const _FlutterDeckSlidePage(this.slide);
-  final FlutterDeckRouterSlide slide;
-
-  @override
-  Widget build(BuildContext context) {
-    return slide.widget.build(context);
-  }
-}
-
 /// A slide route for the slide deck.
 class FlutterDeckRouterSlide {
   /// Creates a slide route for the slide deck.
@@ -74,7 +64,7 @@ class FlutterDeckRouter {
               key: state.pageKey,
               restorationId: state.pageKey.value,
               transitionsBuilder: slide.configuration.transition.build,
-              child: _FlutterDeckSlidePage(slide),
+              child: Builder(builder: slide.widget.build),
             ),
           ),
       ],

--- a/lib/src/widgets/flutter_deck_footer.dart
+++ b/lib/src/widgets/flutter_deck_footer.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';


### PR DESCRIPTION
## Description

Fixed hot reload didn't work proprety when running in macOS desktop mode

This is due to behaviour change in go_router start from 13.0, go_router `pageBuilder` no longer called after hot reload, that mean `slide.widget.build(context)` will only call once on init state, and cause `FlutterDeckSlideWidget.build` will not call again to reflect the change (like change the title in `FlutterDeckSlide.title(title: 'xxx')`)

https://github.com/mkobuolys/flutter_deck/blob/e68f538121dd8a680aeb3e1b35131647357298b2/lib/src/flutter_deck_router.dart#L62-L66

Do fix this issue, this PR will move `slide.widget.build(context)` to a wrapper widget so it will trigger when hot reload is performed

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

