### PR TITLE
feat: added support for localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- feat: add support for slide deck localization
+
 # 0.11.1
 
 - fix: hot reload doesn't work on macOS

--- a/lib/src/flutter_deck_app.dart
+++ b/lib/src/flutter_deck_app.dart
@@ -39,8 +39,8 @@ class FlutterDeckApp extends StatefulWidget {
   /// The [themeMode] argument can be used to provide a custom theme mode for
   /// the slide deck.
   ///
-  /// The [locale], [localizationsDelegates] and [supportedLocales] arguments are
-  /// equivalent to those of [MaterialApp]'s.
+  /// The [locale], [localizationsDelegates] and [supportedLocales] arguments
+  /// are equivalent to those of [MaterialApp]'s.
   ///
   /// See also:
   ///
@@ -111,7 +111,8 @@ class FlutterDeckApp extends StatefulWidget {
   /// The delegates for the slide deck's localization.
   ///
   /// See also:
-  /// * [MaterialApp.localizationsDelegates], which is equivalent to this argument.
+  /// * [MaterialApp.localizationsDelegates], which is equivalent to this
+  /// argument.
   final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
 
   /// The list of locales that the slide deck has been localized for.

--- a/lib/src/flutter_deck_app.dart
+++ b/lib/src/flutter_deck_app.dart
@@ -39,6 +39,9 @@ class FlutterDeckApp extends StatefulWidget {
   /// The [themeMode] argument can be used to provide a custom theme mode for
   /// the slide deck.
   ///
+  /// The [locale], [localizationsDelegates] and [supportedLocales] arguments are
+  /// equivalent to those of [MaterialApp]'s.
+  ///
   /// See also:
   ///
   /// * [FlutterDeckSlide], which represents a single slide.
@@ -56,6 +59,9 @@ class FlutterDeckApp extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode = ThemeMode.system,
+    this.locale,
+    this.localizationsDelegates,
+    this.supportedLocales = const <Locale>[Locale('en')],
     super.key,
   }) : assert(slides.length > 0, 'You must provide at least one slide');
 
@@ -95,6 +101,24 @@ class FlutterDeckApp extends StatefulWidget {
   ///
   /// By default, the system theme mode is used.
   final ThemeMode themeMode;
+
+  /// The initial locale for the slide.
+  ///
+  /// See also:
+  /// * [MaterialApp.locale], which is equivalent to this argument.
+  final Locale? locale;
+
+  /// The delegates for the slide's localization.
+  ///
+  /// See also:
+  /// * [MaterialApp.localizationsDelegates], which is equivalent to this argument.
+  final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
+
+  /// The list of locales that the slide has been localized for.
+  ///
+  /// See also:
+  /// * [MaterialApp.supportedLocales], which is equivalent to this argument.
+  final Iterable<Locale> supportedLocales;
 
   @override
   State<FlutterDeckApp> createState() => _FlutterDeckAppState();
@@ -173,6 +197,9 @@ class _FlutterDeckAppState extends State<FlutterDeckApp> {
             ),
           ),
           debugShowCheckedModeBanner: false,
+          locale: widget.locale,
+          localizationsDelegates: widget.localizationsDelegates,
+          supportedLocales: widget.supportedLocales,
         );
       },
     );

--- a/lib/src/flutter_deck_app.dart
+++ b/lib/src/flutter_deck_app.dart
@@ -102,19 +102,19 @@ class FlutterDeckApp extends StatefulWidget {
   /// By default, the system theme mode is used.
   final ThemeMode themeMode;
 
-  /// The initial locale for the slide.
+  /// The initial locale for the slide deck.
   ///
   /// See also:
   /// * [MaterialApp.locale], which is equivalent to this argument.
   final Locale? locale;
 
-  /// The delegates for the slide's localization.
+  /// The delegates for the slide deck's localization.
   ///
   /// See also:
   /// * [MaterialApp.localizationsDelegates], which is equivalent to this argument.
   final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
 
-  /// The list of locales that the slide has been localized for.
+  /// The list of locales that the slide deck has been localized for.
   ///
   /// See also:
   /// * [MaterialApp.supportedLocales], which is equivalent to this argument.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Added support for localization of slides by bypassing `MaterialApp`'s parameters for localization.

This would be useful for those (like me) who originally made a slide in a non-English language, Japanese for instance, and want to share it globally with the same URL.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## References

https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization