### PR TITLE
Fix missing dart:ui import error

### DIFF
--- a/lib/src/widgets/flutter_deck_footer.dart
+++ b/lib/src/widgets/flutter_deck_footer.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Importing `dart:ui` is missing and results in the error below.

```sh
../../../.pub-cache/hosted/pub.dev/flutter_deck-0.11.1/lib/src/widgets/flutter_deck_footer.dart:96:38: Error: Undefined name 'FontFeature'.
                fontFeatures: const [FontFeature.tabularFigures()],
                                     ^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/flutter_deck-0.11.1/lib/src/widgets/flutter_deck_footer.dart:96:50: Error: Method invocation is not a constant expression.
                fontFeatures: const [FontFeature.tabularFigures()],
                                                 ^^^^^^^^^^^^^^
Target kernel_snapshot failed: Exception

Command PhaseScriptExecution failed with a nonzero exit code
** BUILD FAILED **
```

One thing I'm curious about is that I could run last week with `0.11.1` and I can't now with `0.12.0` even though this class has no change between `0.11.1` and `0.12.0`. In addition, the error now happens even with `0.11.1`. 

I just stopped taking a closer look at it and just added one line to import.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
