### PR TITLE
feat: Add a builder for speakerInfo

### DIFF
--- a/lib/src/flutter_deck.dart
+++ b/lib/src/flutter_deck.dart
@@ -63,6 +63,7 @@ class FlutterDeck extends InheritedWidget {
     required FlutterDeckConfiguration configuration,
     required FlutterDeckRouter router,
     required FlutterDeckSpeakerInfo? speakerInfo,
+    required FlutterDeckSpeakerInfoBuilder? speakerInfoBuilder,
     required FlutterDeckAutoplayNotifier autoplayNotifier,
     required FlutterDeckControlsNotifier controlsNotifier,
     required FlutterDeckDrawerNotifier drawerNotifier,
@@ -74,6 +75,7 @@ class FlutterDeck extends InheritedWidget {
   })  : _configuration = configuration,
         _router = router,
         _speakerInfo = speakerInfo,
+        _speakerInfoBuilder = speakerInfoBuilder,
         _autoplayNotifier = autoplayNotifier,
         _controlsNotifier = controlsNotifier,
         _drawerNotifier = drawerNotifier,
@@ -84,6 +86,7 @@ class FlutterDeck extends InheritedWidget {
   final FlutterDeckConfiguration _configuration;
   final FlutterDeckRouter _router;
   final FlutterDeckSpeakerInfo? _speakerInfo;
+  final FlutterDeckSpeakerInfoBuilder? _speakerInfoBuilder;
   final FlutterDeckAutoplayNotifier _autoplayNotifier;
   final FlutterDeckControlsNotifier _controlsNotifier;
   final FlutterDeckDrawerNotifier _drawerNotifier;
@@ -124,6 +127,9 @@ class FlutterDeck extends InheritedWidget {
 
   /// Returns the speaker info.
   FlutterDeckSpeakerInfo? get speakerInfo => _speakerInfo;
+
+  /// Returns the builder to build [FlutterDeckSpeakerInfo].
+  FlutterDeckSpeakerInfoBuilder? get speakerInfoBuilder => _speakerInfoBuilder;
 
   /// Returns the configuration for the current slide.
   FlutterDeckSlideConfiguration get configuration =>

--- a/lib/src/flutter_deck_app.dart
+++ b/lib/src/flutter_deck_app.dart
@@ -58,6 +58,7 @@ class FlutterDeckApp extends StatefulWidget {
     required this.slides,
     this.configuration = const FlutterDeckConfiguration(),
     this.speakerInfo,
+    this.speakerInfoBuilder,
     this.lightTheme,
     this.darkTheme,
     this.themeMode = ThemeMode.system,
@@ -88,6 +89,9 @@ class FlutterDeckApp extends StatefulWidget {
 
   /// Information about the speaker.
   final FlutterDeckSpeakerInfo? speakerInfo;
+
+  /// Builder function to create [FlutterDeckSpeakerInfo] using [BuildContext].
+  final FlutterDeckSpeakerInfoBuilder? speakerInfoBuilder;
 
   /// The theme to use when the app is in light mode.
   ///
@@ -194,6 +198,7 @@ class _FlutterDeckAppState extends State<FlutterDeckApp> {
               configuration: widget.configuration,
               router: _flutterDeckRouter,
               speakerInfo: widget.speakerInfo,
+              speakerInfoBuilder: widget.speakerInfoBuilder,
               autoplayNotifier: _autoplayNotifier,
               controlsNotifier: _controlsNotifier,
               drawerNotifier: _drawerNotifier,

--- a/lib/src/flutter_deck_speaker_info.dart
+++ b/lib/src/flutter_deck_speaker_info.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+
 /// Stores information about the speaker.
 class FlutterDeckSpeakerInfo {
   /// Creates a new [FlutterDeckSpeakerInfo] instance.
@@ -24,3 +26,8 @@ class FlutterDeckSpeakerInfo {
   /// This should be a path to an image asset in the app's assets directory.
   final String imagePath;
 }
+
+/// A function to build [FlutterDeckSpeakerInfo] instance using [BuildContext].
+typedef FlutterDeckSpeakerInfoBuilder = FlutterDeckSpeakerInfo Function(
+  BuildContext context,
+);

--- a/lib/src/templates/title_slide.dart
+++ b/lib/src/templates/title_slide.dart
@@ -47,7 +47,8 @@ class FlutterDeckTitleSlide extends StatelessWidget {
     final configuration = context.flutterDeck.configuration;
     final footerConfiguration = configuration.footer;
     final headerConfiguration = configuration.header;
-    final speakerInfo = context.flutterDeck.speakerInfo;
+    final speakerInfo = context.flutterDeck.speakerInfo ??
+        context.flutterDeck.speakerInfoBuilder?.call(context);
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,

--- a/lib/src/widgets/flutter_deck_footer.dart
+++ b/lib/src/widgets/flutter_deck_footer.dart
@@ -69,6 +69,8 @@ class FlutterDeckFooter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckFooterTheme.of(context);
+    final speakerInfo = context.flutterDeck.speakerInfo ??
+        context.flutterDeck.speakerInfoBuilder?.call(context);
 
     return Padding(
       padding: FlutterDeckLayout.slidePadding,
@@ -83,7 +85,7 @@ class FlutterDeckFooter extends StatelessWidget {
             )
           else if (showSocialHandle)
             Text(
-              context.flutterDeck.speakerInfo?.socialHandle ?? '',
+              speakerInfo?.socialHandle ?? '',
               style: theme.socialHandleTextStyle?.copyWith(
                 color: theme.socialHandleColor,
                 fontWeight: FontWeight.bold,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Related to #62, I found another issue that `speakerInfo` can't be localized as the object is created outside of `FlutterDeckApp`, meaning outside of `MaterialApp`.

I could solve the problem by wrapping `FlutterDeckApp` with another `MaterialApp` like below

```dart
MaterialApp(
  debugShowCheckedModeBanner: false,
  localizationsDelegates: AppLocalizations.localizationsDelegates,
  supportedLocales: AppLocalizations.supportedLocales,
  home: Builder(
    builder: (c) => FlutterDeckApp(
      speakerInfo: FlutterDeckSpeakerInfo(
        name: AppLocalizations.of(c)!.name,
        description: AppLocalizations.of(c)!.occupation,
        imagePath: 'assets/images/${AppLocalizations.of(c)!.imageFile}',
        socialHandle: AppLocalizations.of(c)!.social,
      ),
    ),
  ),
);
``` 

but that seems inefficient, and the biggest problem is that changing the locale feature of the control is not applied on `FlutterDeckTitleSlide`.

Here is my proposal to add a `Builder` version of `speakerInfo` which allows users to use `BuildContext` that is at least a descendant of `FlutterDeckApp`.

This enables users to simply write like below.

```dart
FlutterDeckApp(
  speakerInfoBuilder: (context) => FlutterDeckSpeakerInfo(
    name: AppLocalizations.of(context)!.name,
    description: AppLocalizations.of(context)!.occupation,
    imagePath: 'assets/images/${AppLocalizations.of(context)!.imageFile}',
    socialHandle: AppLocalizations.of(context)!.social,
  ),
);
``` 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
