### PR TITLE
feat: add stepOffset to BulletList

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ A widget that renders a list of bullet points. Bullet point items are rendered a
 
 If `useSteps` is true for the slide configuration, the bullet points will be rendered one by one as the user steps through the slide.
 
+You can use `stepOffset` to shift the Item's appearance. e.g. if you set `stepOffset: 1,` the first item will only show after the first step has been made. Remember to increase the `steps` of the Slide Configuration.
+
 ```dart
 class FlutterDeckBulletListDemoSlide extends FlutterDeckSlideWidget {
   const FlutterDeckBulletListDemoSlide()

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ A widget that renders a list of bullet points. Bullet point items are rendered a
 
 If `useSteps` is true for the slide configuration, the bullet points will be rendered one by one as the user steps through the slide.
 
-You can use `stepOffset` to shift the Item's appearance. e.g. if you set `stepOffset: 1,` the first item will only show after the first step has been made. Remember to increase the `steps` of the Slide Configuration.
+You can use `stepOffset` to offset the step number for the first item in the list. For instance, if you set `stepOffset` to 1, the first item will only be visible when the user steps to the second step. Remember to increase the number of `steps` for the slide configuration if you use `stepOffset`.
 
 ```dart
 class FlutterDeckBulletListDemoSlide extends FlutterDeckSlideWidget {
@@ -931,16 +931,16 @@ You can change the locale of the slide deck at runtime. The updated locale will 
 
 ## 🚀 Presentations built with flutter_deck
 
-| Title                                                                                                                                                           | Language   | Author                                                                                       |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------- |
-| [Let me introduce you to Flutter](https://github.com/mkobuolys/introduction-to-flutter)                                                                         | English    | [Mangirdas Kazlauskas][mangirdas_kazlauskas_link]                                            |
-| [Control your Flutter application on the fly with Firebase Remote Config](https://github.com/mkobuolys/firebase-remote-config-talk)                             | English    | [Mangirdas Kazlauskas][mangirdas_kazlauskas_link]                                            |
-| [Introduction to Flutter Web](https://github.com/afucher/flutter_web_101)                                                                                       | Portuguese | [Arthur Fücher](https://x.com/Thur)                                                          |
-| [Make smarter decisions faster with Firebase Remote Config](https://github.com/mkobuolys/f3-firebase-remote-config-talk)                                        | English    | [Mangirdas Kazlauskas][mangirdas_kazlauskas_link] & [Darja Orlova](https://x.com/dariadroid) |
-| [Flutter for the win: Cross-platform development at maximum power](https://github.com/polilluminato/linuxday-2023-presentation)                                 | Italian    | [Alberto Bonacina](https://x.com/polilluminato)                                              |
-| [ReArch: A Reactive Approach to Application Architecture Supporting Side Effects](https://github.com/GregoryConrad/rearch-dart/tree/main/examples/presentation) | English    | [Gregory Conrad](https://github.com/GregoryConrad)                                           |
-| [Flutter demo](https://github.com/thpir/flutter-presentation)                                                                                                   | Dutch      | [Thijs Pirmez](https://www.linkedin.com/in/thijs-pirmez-973327230/)                          |
-| [Build Dynamic Slide Decks with Flutter](https://github.com/chooyan-eng/slide_decks_with_flutter)                                                               | English / Japanese | [Tsuyoshi Chujo](https://twitter.com/tsuyoshi_chujo)                          |
+| Title                                                                                                                                                           | Language           | Author                                                                                       |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------- |
+| [Let me introduce you to Flutter](https://github.com/mkobuolys/introduction-to-flutter)                                                                         | English            | [Mangirdas Kazlauskas][mangirdas_kazlauskas_link]                                            |
+| [Control your Flutter application on the fly with Firebase Remote Config](https://github.com/mkobuolys/firebase-remote-config-talk)                             | English            | [Mangirdas Kazlauskas][mangirdas_kazlauskas_link]                                            |
+| [Introduction to Flutter Web](https://github.com/afucher/flutter_web_101)                                                                                       | Portuguese         | [Arthur Fücher](https://x.com/Thur)                                                          |
+| [Make smarter decisions faster with Firebase Remote Config](https://github.com/mkobuolys/f3-firebase-remote-config-talk)                                        | English            | [Mangirdas Kazlauskas][mangirdas_kazlauskas_link] & [Darja Orlova](https://x.com/dariadroid) |
+| [Flutter for the win: Cross-platform development at maximum power](https://github.com/polilluminato/linuxday-2023-presentation)                                 | Italian            | [Alberto Bonacina](https://x.com/polilluminato)                                              |
+| [ReArch: A Reactive Approach to Application Architecture Supporting Side Effects](https://github.com/GregoryConrad/rearch-dart/tree/main/examples/presentation) | English            | [Gregory Conrad](https://github.com/GregoryConrad)                                           |
+| [Flutter demo](https://github.com/thpir/flutter-presentation)                                                                                                   | Dutch              | [Thijs Pirmez](https://www.linkedin.com/in/thijs-pirmez-973327230/)                          |
+| [Build Dynamic Slide Decks with Flutter](https://github.com/chooyan-eng/slide_decks_with_flutter)                                                               | English / Japanese | [Tsuyoshi Chujo](https://twitter.com/tsuyoshi_chujo)                                         |
 
 [flutter_install_link]: https://docs.flutter.dev/get-started/install
 [license_badge]: https://img.shields.io/badge/license-MIT-blue.svg

--- a/lib/src/widgets/flutter_deck_bullet_list.dart
+++ b/lib/src/widgets/flutter_deck_bullet_list.dart
@@ -58,6 +58,7 @@ class FlutterDeckBulletList extends StatefulWidget {
   FlutterDeckBulletList({
     this.items = const [],
     this.useSteps = false,
+    this.stepOffset = 0,
     this.bulletPointWidget,
     super.key,
   }) : assert(items.isNotEmpty, 'You must provide at least one bullet point.');
@@ -68,6 +69,15 @@ class FlutterDeckBulletList extends StatefulWidget {
   /// Whether to render the bullet points one by one as the user steps through
   /// the slide.
   final bool useSteps;
+
+  /// Use this to offset the list items steps
+  /// If this is `1` the first item will not be shown directly
+  ///
+  /// This can be uses to start showing items from the list later in a slide if
+  /// e.g the bullet list is on the right side of a slide
+  ///
+  /// If this is negative you can show more than just the first item directly
+  final int stepOffset;
 
   /// A widget to use as the bullet point. If not provided, a dot will be used.
   final Widget? bulletPointWidget;
@@ -94,7 +104,7 @@ class _FlutterDeckBulletListState extends State<FlutterDeckBulletList> {
         items: widget.items,
         autoSizeGroup: _autoSizeGroup,
         bulletPointWidget: widget.bulletPointWidget,
-        stepNumber: stepNumber,
+        stepNumber: stepNumber - widget.stepOffset,
       ),
     );
   }

--- a/lib/src/widgets/flutter_deck_bullet_list.dart
+++ b/lib/src/widgets/flutter_deck_bullet_list.dart
@@ -70,13 +70,18 @@ class FlutterDeckBulletList extends StatefulWidget {
   /// the slide.
   final bool useSteps;
 
-  /// Use this to offset the list items steps
-  /// If this is `1` the first item will not be shown directly
+  /// Use this to offset the step number for the first item in the list. This
+  /// can be used to start showing [items] later in a slide. For instance, when
+  /// you have two bullet lists on the same slide, and you want to show the
+  /// second list after the first one.
   ///
-  /// This can be uses to start showing items from the list later in a slide if
-  /// e.g the bullet list is on the right side of a slide
+  /// If the value is `1`, the first item in the list will not be shown
+  /// directly.
   ///
-  /// If this is negative you can show more than just the first item directly
+  /// If the value is negative, you can show more than just the first item
+  /// directly.
+  ///
+  /// Default is `0` (no offset).
   final int stepOffset;
 
   /// A widget to use as the bullet point. If not provided, a dot will be used.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adding an optional `stepOffset` to FlutterDeckBullet List. This can be used to not show the first item directly. Or use a Bullet List in the right side of a Split slide that starts after the left side is finished.

Originally I wanted to write a test for this but could not find a direct way of stepping in the test. Maybe something useful to add to the `SlideTester`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
