### PR TITLE
fix: backgroundBuilder not working with Split Slide

### DIFF
--- a/lib/src/templates/split_slide.dart
+++ b/lib/src/templates/split_slide.dart
@@ -76,20 +76,21 @@ class FlutterDeckSplitSlide extends StatelessWidget {
     final headerConfiguration = configuration.header;
 
     return FlutterDeckSlideBase(
-      backgroundBuilder: (context) => FlutterDeckBackground.custom(
-        child: Row(
-          children: [
-            _BackgroundSection(
-              flex: splitRatio.left,
-              color: theme.leftBackgroundColor,
-            ),
-            _BackgroundSection(
-              flex: splitRatio.right,
-              color: theme.rightBackgroundColor,
-            ),
-          ],
-        ),
-      ),
+      backgroundBuilder: backgroundBuilder ??
+          (context) => FlutterDeckBackground.custom(
+                child: Row(
+                  children: [
+                    _BackgroundSection(
+                      flex: splitRatio.left,
+                      color: theme.leftBackgroundColor,
+                    ),
+                    _BackgroundSection(
+                      flex: splitRatio.right,
+                      color: theme.rightBackgroundColor,
+                    ),
+                  ],
+                ),
+              ),
       contentBuilder: (context) => Row(
         children: [
           _ContentSection(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

`backgroundBuilder` was not used in SplitSlide

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
