### PR TITLE
feat: support header, footer and speaker info builder overrides in slide templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# NEXT
+
+- feat: support header and footer builder overrides in slide templates
+- feat: add `stepOffset` property to `FlutterDeckBulletList`
+- fix: `backgroundBuilder` not working with `FlutterDeckSlide.split`
+
 # 0.12.2
 
 - fix: ignore unnecessary_import lint rule

--- a/lib/src/flutter_deck_slide.dart
+++ b/lib/src/flutter_deck_slide.dart
@@ -312,8 +312,8 @@ class FlutterDeckSlide extends StatelessWidget {
   /// it will render the speaker info below the title and subtitle.
   ///
   /// The [title] argument must not be null. The [subtitle],
-  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
-  /// optional.
+  /// [backgroundBuilder], [footerBuilder], [headerBuilder], and
+  /// [speakerInfoBuilder] arguments are optional.
   ///
   /// The passed [theme] will be merged with global [FlutterDeckTheme] data.
   FlutterDeckSlide.title({
@@ -322,6 +322,7 @@ class FlutterDeckSlide extends StatelessWidget {
     WidgetBuilder? backgroundBuilder,
     WidgetBuilder? footerBuilder,
     WidgetBuilder? headerBuilder,
+    WidgetBuilder? speakerInfoBuilder,
     FlutterDeckThemeData? theme,
     Key? key,
   }) : this._(
@@ -331,6 +332,7 @@ class FlutterDeckSlide extends StatelessWidget {
             backgroundBuilder: backgroundBuilder,
             footerBuilder: footerBuilder,
             headerBuilder: headerBuilder,
+            speakerInfoBuilder: speakerInfoBuilder,
           ),
           theme: theme,
           key: key,

--- a/lib/src/flutter_deck_slide.dart
+++ b/lib/src/flutter_deck_slide.dart
@@ -99,8 +99,9 @@ class FlutterDeckSlide extends StatelessWidget {
   /// This constructor creates a big fact slide in a slide deck with the default
   /// header and footer.
   ///
-  /// The [title] argument must not be null. The [subtitle] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [title] argument must not be null. The [subtitle],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   ///
   /// [subtitleMaxLines] is the maximum number of lines for the subtitle. By
   /// default it is 3.
@@ -110,6 +111,8 @@ class FlutterDeckSlide extends StatelessWidget {
     required String title,
     String? subtitle,
     WidgetBuilder? backgroundBuilder,
+    WidgetBuilder? footerBuilder,
+    WidgetBuilder? headerBuilder,
     int? subtitleMaxLines,
     FlutterDeckThemeData? theme,
     Key? key,
@@ -118,6 +121,8 @@ class FlutterDeckSlide extends StatelessWidget {
             title: title,
             subtitle: subtitle,
             backgroundBuilder: backgroundBuilder,
+            footerBuilder: footerBuilder,
+            headerBuilder: headerBuilder,
             subtitleMaxLines: subtitleMaxLines,
           ),
           theme: theme,
@@ -129,19 +134,23 @@ class FlutterDeckSlide extends StatelessWidget {
   /// This constructor creates a blank slide in a slide deck with the default
   /// header and footer, and the content in-between.
   ///
-  /// The [builder] argument must not be null. The [backgroundBuilder] argument
-  /// is optional.
+  /// The [builder] argument must not be null. The [backgroundBuilder],
+  /// [footerBuilder], and [headerBuilder] arguments are optional.
   ///
   /// The passed [theme] will be merged with global [FlutterDeckTheme] data.
   FlutterDeckSlide.blank({
     required WidgetBuilder builder,
     WidgetBuilder? backgroundBuilder,
+    WidgetBuilder? footerBuilder,
+    WidgetBuilder? headerBuilder,
     FlutterDeckThemeData? theme,
     Key? key,
   }) : this._(
           builder: (context) => FlutterDeckBlankSlide(
             builder: builder,
             backgroundBuilder: backgroundBuilder,
+            footerBuilder: footerBuilder,
+            headerBuilder: headerBuilder,
           ),
           theme: theme,
           key: key,
@@ -172,14 +181,17 @@ class FlutterDeckSlide extends StatelessWidget {
   /// and footer, and the image in-between.The image can be a local asset or a
   /// network image.
   ///
-  /// The [imageBuilder] argument must not be null. The [label] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [imageBuilder] argument must not be null. The [label],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   ///
   /// The passed [theme] will be merged with global [FlutterDeckTheme] data.
   FlutterDeckSlide.image({
     required ImageBuilder imageBuilder,
     String? label,
     WidgetBuilder? backgroundBuilder,
+    WidgetBuilder? footerBuilder,
+    WidgetBuilder? headerBuilder,
     FlutterDeckThemeData? theme,
     Key? key,
   }) : this._(
@@ -187,6 +199,8 @@ class FlutterDeckSlide extends StatelessWidget {
             imageBuilder: imageBuilder,
             label: label,
             backgroundBuilder: backgroundBuilder,
+            footerBuilder: footerBuilder,
+            headerBuilder: headerBuilder,
           ),
           theme: theme,
           key: key,
@@ -197,8 +211,9 @@ class FlutterDeckSlide extends StatelessWidget {
   /// This constructor creates a quote slide in a slide deck with the default
   /// header and footer.
   ///
-  /// The [quote] argument must not be null. The [attribution] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [quote] argument must not be null. The [attribution],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   ///
   /// [quoteMaxLines] is the maximum number of lines for the quote. By default
   /// it is 5.
@@ -208,6 +223,8 @@ class FlutterDeckSlide extends StatelessWidget {
     required String quote,
     String? attribution,
     WidgetBuilder? backgroundBuilder,
+    WidgetBuilder? footerBuilder,
+    WidgetBuilder? headerBuilder,
     int? quoteMaxLines,
     FlutterDeckThemeData? theme,
     Key? key,
@@ -217,6 +234,8 @@ class FlutterDeckSlide extends StatelessWidget {
             attribution: attribution,
             quoteMaxLines: quoteMaxLines,
             backgroundBuilder: backgroundBuilder,
+            footerBuilder: footerBuilder,
+            headerBuilder: headerBuilder,
           ),
           theme: theme,
           key: key,
@@ -230,7 +249,8 @@ class FlutterDeckSlide extends StatelessWidget {
   /// left and right columns.
   ///
   /// The [leftBuilder] and [rightBuilder] arguments must not be null. The
-  /// [backgroundBuilder] and [splitRatio] arguments are optional.
+  /// [backgroundBuilder], [footerBuilder], [headerBuilder], and [splitRatio]
+  /// arguments are optional.
   ///
   /// If [splitRatio] is not specified, the left and right columns will have the
   /// same width.
@@ -240,6 +260,8 @@ class FlutterDeckSlide extends StatelessWidget {
     required WidgetBuilder leftBuilder,
     required WidgetBuilder rightBuilder,
     WidgetBuilder? backgroundBuilder,
+    WidgetBuilder? footerBuilder,
+    WidgetBuilder? headerBuilder,
     SplitSlideRatio? splitRatio,
     FlutterDeckThemeData? theme,
     Key? key,
@@ -248,6 +270,8 @@ class FlutterDeckSlide extends StatelessWidget {
             leftBuilder: leftBuilder,
             rightBuilder: rightBuilder,
             backgroundBuilder: backgroundBuilder,
+            footerBuilder: footerBuilder,
+            headerBuilder: headerBuilder,
             splitRatio: splitRatio,
           ),
           theme: theme,
@@ -287,14 +311,17 @@ class FlutterDeckSlide extends StatelessWidget {
   /// the [title] and [subtitle]. Also, if the [FlutterDeckSpeakerInfo] is set,
   /// it will render the speaker info below the title and subtitle.
   ///
-  /// The [title] argument must not be null. The [subtitle] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [title] argument must not be null. The [subtitle],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   ///
   /// The passed [theme] will be merged with global [FlutterDeckTheme] data.
   FlutterDeckSlide.title({
     required String title,
     String? subtitle,
     WidgetBuilder? backgroundBuilder,
+    WidgetBuilder? footerBuilder,
+    WidgetBuilder? headerBuilder,
     FlutterDeckThemeData? theme,
     Key? key,
   }) : this._(
@@ -302,6 +329,8 @@ class FlutterDeckSlide extends StatelessWidget {
             title: title,
             subtitle: subtitle,
             backgroundBuilder: backgroundBuilder,
+            footerBuilder: footerBuilder,
+            headerBuilder: headerBuilder,
           ),
           theme: theme,
           key: key,

--- a/lib/src/templates/big_fact_slide.dart
+++ b/lib/src/templates/big_fact_slide.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
 import 'package:flutter_deck/src/templates/slide_base.dart';
@@ -14,11 +15,18 @@ import 'package:flutter_deck/src/widgets/widgets.dart';
 /// if they are enabled in the configuration.
 ///
 /// To use a custom background, you can pass the [backgroundBuilder].
+///
+/// To use a custom footer, you can pass the [footerBuilder].
+///
+/// To use a custom header, you can pass the [headerBuilder].
+///
+/// This template uses the [FlutterDeckBigFactSlideTheme] to style the slide.
 class FlutterDeckBigFactSlide extends StatelessWidget {
   /// Creates a new big fact slide.
   ///
-  /// The [title] argument must not be null. The [subtitle] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [title] argument must not be null. The [subtitle],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   ///
   /// [subtitleMaxLines] is the maximum number of lines for the subtitle. By
   /// default it is 3.
@@ -27,6 +35,8 @@ class FlutterDeckBigFactSlide extends StatelessWidget {
     this.subtitle,
     int? subtitleMaxLines,
     this.backgroundBuilder,
+    this.footerBuilder,
+    this.headerBuilder,
     super.key,
   }) : subtitleMaxLines = subtitleMaxLines ?? 3;
 
@@ -42,12 +52,31 @@ class FlutterDeckBigFactSlide extends StatelessWidget {
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
 
+  /// A builder for the footer of the slide.
+  final WidgetBuilder? footerBuilder;
+
+  /// A builder for the header of the slide.
+  final WidgetBuilder? headerBuilder;
+
+  Widget _buildFooter(BuildContext context) =>
+      footerBuilder?.call(context) ??
+      FlutterDeckFooter.fromConfiguration(
+        configuration: context.flutterDeck.configuration.footer,
+      );
+
+  Widget _buildHeader(BuildContext context) =>
+      headerBuilder?.call(context) ??
+      FlutterDeckHeader.fromConfiguration(
+        configuration: context.flutterDeck.configuration.header,
+      );
+
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckBigFactSlideTheme.of(context);
-    final configuration = context.flutterDeck.configuration;
-    final footerConfiguration = configuration.footer;
-    final headerConfiguration = configuration.header;
+    final FlutterDeckSlideConfiguration(
+      footer: footerConfiguration,
+      header: headerConfiguration,
+    ) = context.flutterDeck.configuration;
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,
@@ -80,16 +109,8 @@ class FlutterDeckBigFactSlide extends StatelessWidget {
           ),
         ),
       ),
-      footerBuilder: footerConfiguration.showFooter
-          ? (context) => FlutterDeckFooter.fromConfiguration(
-                configuration: footerConfiguration,
-              )
-          : null,
-      headerBuilder: headerConfiguration.showHeader
-          ? (context) => FlutterDeckHeader.fromConfiguration(
-                configuration: headerConfiguration,
-              )
-          : null,
+      footerBuilder: footerConfiguration.showFooter ? _buildFooter : null,
+      headerBuilder: headerConfiguration.showHeader ? _buildHeader : null,
     );
   }
 }

--- a/lib/src/templates/blank_slide.dart
+++ b/lib/src/templates/blank_slide.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
 import 'package:flutter_deck/src/templates/slide_base.dart';
@@ -11,14 +12,20 @@ import 'package:flutter_deck/src/widgets/widgets.dart';
 /// and rendering the content of the slide using the provided [builder].
 ///
 /// To use a custom background, you can pass the [backgroundBuilder].
+///
+/// To use a custom footer, you can pass the [footerBuilder].
+///
+/// To use a custom header, you can pass the [headerBuilder].
 class FlutterDeckBlankSlide extends StatelessWidget {
   /// Creates a new blank slide.
   ///
-  /// The [builder] argument must not be null. The [backgroundBuilder] argument
-  /// is optional.
+  /// The [builder] argument must not be null. The [backgroundBuilder],
+  /// [footerBuilder], and [headerBuilder] argument are optional.
   const FlutterDeckBlankSlide({
     required this.builder,
     this.backgroundBuilder,
+    this.footerBuilder,
+    this.headerBuilder,
     super.key,
   });
 
@@ -28,11 +35,30 @@ class FlutterDeckBlankSlide extends StatelessWidget {
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
 
+  /// A builder for the footer of the slide.
+  final WidgetBuilder? footerBuilder;
+
+  /// A builder for the header of the slide.
+  final WidgetBuilder? headerBuilder;
+
+  Widget _buildFooter(BuildContext context) =>
+      footerBuilder?.call(context) ??
+      FlutterDeckFooter.fromConfiguration(
+        configuration: context.flutterDeck.configuration.footer,
+      );
+
+  Widget _buildHeader(BuildContext context) =>
+      headerBuilder?.call(context) ??
+      FlutterDeckHeader.fromConfiguration(
+        configuration: context.flutterDeck.configuration.header,
+      );
+
   @override
   Widget build(BuildContext context) {
-    final configuration = context.flutterDeck.configuration;
-    final footerConfiguration = configuration.footer;
-    final headerConfiguration = configuration.header;
+    final FlutterDeckSlideConfiguration(
+      footer: footerConfiguration,
+      header: headerConfiguration,
+    ) = context.flutterDeck.configuration;
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,
@@ -40,16 +66,8 @@ class FlutterDeckBlankSlide extends StatelessWidget {
         padding: FlutterDeckLayout.slidePadding,
         child: builder(context),
       ),
-      footerBuilder: footerConfiguration.showFooter
-          ? (context) => FlutterDeckFooter.fromConfiguration(
-                configuration: footerConfiguration,
-              )
-          : null,
-      headerBuilder: headerConfiguration.showHeader
-          ? (context) => FlutterDeckHeader.fromConfiguration(
-                configuration: headerConfiguration,
-              )
-          : null,
+      footerBuilder: footerConfiguration.showFooter ? _buildFooter : null,
+      headerBuilder: headerConfiguration.showHeader ? _buildHeader : null,
     );
   }
 }

--- a/lib/src/templates/image_slide.dart
+++ b/lib/src/templates/image_slide.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
 import 'package:flutter_deck/src/templates/slide_base.dart';
@@ -16,16 +17,23 @@ typedef ImageBuilder = Image Function(BuildContext context);
 ///
 /// To use a custom background, you can pass the [backgroundBuilder].
 ///
+/// To use a custom footer, you can pass the [footerBuilder].
+///
+/// To use a custom header, you can pass the [headerBuilder].
+///
 /// This template uses the [FlutterDeckImageSlideTheme] to style the slide.
 class FlutterDeckImageSlide extends StatelessWidget {
   /// Creates a new image slide.
   ///
-  /// The [imageBuilder] argument must not be null. The [label] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [imageBuilder] argument must not be null. The [label],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   const FlutterDeckImageSlide({
     required this.imageBuilder,
     this.label,
     this.backgroundBuilder,
+    this.footerBuilder,
+    this.headerBuilder,
     super.key,
   });
 
@@ -40,12 +48,31 @@ class FlutterDeckImageSlide extends StatelessWidget {
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
 
+  /// A builder for the footer of the slide.
+  final WidgetBuilder? footerBuilder;
+
+  /// A builder for the header of the slide.
+  final WidgetBuilder? headerBuilder;
+
+  Widget _buildFooter(BuildContext context) =>
+      footerBuilder?.call(context) ??
+      FlutterDeckFooter.fromConfiguration(
+        configuration: context.flutterDeck.configuration.footer,
+      );
+
+  Widget _buildHeader(BuildContext context) =>
+      headerBuilder?.call(context) ??
+      FlutterDeckHeader.fromConfiguration(
+        configuration: context.flutterDeck.configuration.header,
+      );
+
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckImageSlideTheme.of(context);
-    final configuration = context.flutterDeck.configuration;
-    final footerConfiguration = configuration.footer;
-    final headerConfiguration = configuration.header;
+    final FlutterDeckSlideConfiguration(
+      footer: footerConfiguration,
+      header: headerConfiguration,
+    ) = context.flutterDeck.configuration;
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,
@@ -63,16 +90,8 @@ class FlutterDeckImageSlide extends StatelessWidget {
           ],
         ),
       ),
-      footerBuilder: footerConfiguration.showFooter
-          ? (context) => FlutterDeckFooter.fromConfiguration(
-                configuration: footerConfiguration,
-              )
-          : null,
-      headerBuilder: headerConfiguration.showHeader
-          ? (context) => FlutterDeckHeader.fromConfiguration(
-                configuration: headerConfiguration,
-              )
-          : null,
+      footerBuilder: footerConfiguration.showFooter ? _buildFooter : null,
+      headerBuilder: headerConfiguration.showHeader ? _buildHeader : null,
     );
   }
 }

--- a/lib/src/templates/quote_slide.dart
+++ b/lib/src/templates/quote_slide.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
 import 'package:flutter_deck/src/templates/slide_base.dart';
@@ -14,11 +15,18 @@ import 'package:flutter_deck/src/widgets/widgets.dart';
 /// enabled in the configuration.
 ///
 /// To use a custom background, you can pass the [backgroundBuilder].
+///
+/// To use a custom footer, you can pass the [footerBuilder].
+///
+/// To use a custom header, you can pass the [headerBuilder].
+///
+/// This template uses the [FlutterDeckQuoteSlideTheme] to style the slide.
 class FlutterDeckQuoteSlide extends StatelessWidget {
   /// Creates a new quote slide.
   ///
-  /// The [quote] argument must not be null. The [attribution] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [quote] argument must not be null. The [attribution],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   ///
   /// [quoteMaxLines] is the maximum number of lines for the quote. By default
   /// it is 5.
@@ -27,6 +35,8 @@ class FlutterDeckQuoteSlide extends StatelessWidget {
     this.attribution,
     int? quoteMaxLines,
     this.backgroundBuilder,
+    this.footerBuilder,
+    this.headerBuilder,
     super.key,
   }) : quoteMaxLines = quoteMaxLines ?? 5;
 
@@ -42,12 +52,31 @@ class FlutterDeckQuoteSlide extends StatelessWidget {
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
 
+  /// A builder for the footer of the slide.
+  final WidgetBuilder? footerBuilder;
+
+  /// A builder for the header of the slide.
+  final WidgetBuilder? headerBuilder;
+
+  Widget _buildFooter(BuildContext context) =>
+      footerBuilder?.call(context) ??
+      FlutterDeckFooter.fromConfiguration(
+        configuration: context.flutterDeck.configuration.footer,
+      );
+
+  Widget _buildHeader(BuildContext context) =>
+      headerBuilder?.call(context) ??
+      FlutterDeckHeader.fromConfiguration(
+        configuration: context.flutterDeck.configuration.header,
+      );
+
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckQuoteSlideTheme.of(context);
-    final configuration = context.flutterDeck.configuration;
-    final footerConfiguration = configuration.footer;
-    final headerConfiguration = configuration.header;
+    final FlutterDeckSlideConfiguration(
+      footer: footerConfiguration,
+      header: headerConfiguration,
+    ) = context.flutterDeck.configuration;
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,
@@ -80,16 +109,8 @@ class FlutterDeckQuoteSlide extends StatelessWidget {
           ),
         ),
       ),
-      footerBuilder: footerConfiguration.showFooter
-          ? (context) => FlutterDeckFooter.fromConfiguration(
-                configuration: footerConfiguration,
-              )
-          : null,
-      headerBuilder: headerConfiguration.showHeader
-          ? (context) => FlutterDeckHeader.fromConfiguration(
-                configuration: headerConfiguration,
-              )
-          : null,
+      footerBuilder: footerConfiguration.showFooter ? _buildFooter : null,
+      headerBuilder: headerConfiguration.showHeader ? _buildHeader : null,
     );
   }
 }

--- a/lib/src/templates/split_slide.dart
+++ b/lib/src/templates/split_slide.dart
@@ -100,23 +100,24 @@ class FlutterDeckSplitSlide extends StatelessWidget {
   Widget _buildHeader(BuildContext context) {
     final theme = FlutterDeckSplitSlideTheme.of(context);
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final maxWidth = constraints.maxWidth *
-            splitRatio.left /
-            (splitRatio.left + splitRatio.right);
+    return headerBuilder?.call(context) ??
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final maxWidth = constraints.maxWidth *
+                splitRatio.left /
+                (splitRatio.left + splitRatio.right);
 
-        return FlutterDeckHeaderTheme(
-          data: FlutterDeckHeaderTheme.of(context).copyWith(
-            color: theme.leftColor,
-          ),
-          child: FlutterDeckHeader.fromConfiguration(
-            configuration: context.flutterDeck.configuration.header,
-            maxWidth: maxWidth,
-          ),
+            return FlutterDeckHeaderTheme(
+              data: FlutterDeckHeaderTheme.of(context).copyWith(
+                color: theme.leftColor,
+              ),
+              child: FlutterDeckHeader.fromConfiguration(
+                configuration: context.flutterDeck.configuration.header,
+                maxWidth: maxWidth,
+              ),
+            );
+          },
         );
-      },
-    );
   }
 
   @override

--- a/lib/src/templates/split_slide.dart
+++ b/lib/src/templates/split_slide.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
 import 'package:flutter_deck/src/templates/slide_base.dart';
@@ -37,12 +38,17 @@ class SplitSlideRatio {
 ///
 /// To use a custom background, you can pass the [backgroundBuilder].
 ///
+/// To use a custom footer, you can pass the [footerBuilder].
+///
+/// To use a custom header, you can pass the [headerBuilder].
+///
 /// This template uses the [FlutterDeckSplitSlideTheme] to style the slide.
 class FlutterDeckSplitSlide extends StatelessWidget {
   /// Creates a new split slide.
   ///
   /// The [leftBuilder] and [rightBuilder] arguments must not be null. The
-  /// [backgroundBuilder] and [splitRatio] arguments are optional.
+  /// [backgroundBuilder], [footerBuilder], [headerBuilder] and [splitRatio]
+  /// arguments are optional.
   ///
   /// If [splitRatio] is not specified, the left and right columns will have the
   /// same width.
@@ -50,6 +56,8 @@ class FlutterDeckSplitSlide extends StatelessWidget {
     required this.leftBuilder,
     required this.rightBuilder,
     this.backgroundBuilder,
+    this.footerBuilder,
+    this.headerBuilder,
     SplitSlideRatio? splitRatio,
     super.key,
   }) : splitRatio = splitRatio ?? const SplitSlideRatio();
@@ -63,17 +71,61 @@ class FlutterDeckSplitSlide extends StatelessWidget {
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
 
+  /// A builder for the footer of the slide.
+  final WidgetBuilder? footerBuilder;
+
+  /// A builder for the header of the slide.
+  final WidgetBuilder? headerBuilder;
+
   /// The ratio of the left and right columns.
   ///
   /// By default, the left and right columns will have the same width.
   final SplitSlideRatio splitRatio;
 
+  Widget _buildFooter(BuildContext context) {
+    final theme = FlutterDeckSplitSlideTheme.of(context);
+
+    return footerBuilder?.call(context) ??
+        FlutterDeckFooterTheme(
+          data: FlutterDeckFooterTheme.of(context).copyWith(
+            slideNumberColor: theme.rightColor,
+            socialHandleColor: theme.leftColor,
+          ),
+          child: FlutterDeckFooter.fromConfiguration(
+            configuration: context.flutterDeck.configuration.footer,
+          ),
+        );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    final theme = FlutterDeckSplitSlideTheme.of(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth *
+            splitRatio.left /
+            (splitRatio.left + splitRatio.right);
+
+        return FlutterDeckHeaderTheme(
+          data: FlutterDeckHeaderTheme.of(context).copyWith(
+            color: theme.leftColor,
+          ),
+          child: FlutterDeckHeader.fromConfiguration(
+            configuration: context.flutterDeck.configuration.header,
+            maxWidth: maxWidth,
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckSplitSlideTheme.of(context);
-    final configuration = context.flutterDeck.configuration;
-    final footerConfiguration = configuration.footer;
-    final headerConfiguration = configuration.header;
+    final FlutterDeckSlideConfiguration(
+      footer: footerConfiguration,
+      header: headerConfiguration,
+    ) = context.flutterDeck.configuration;
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder ??
@@ -105,36 +157,8 @@ class FlutterDeckSplitSlide extends StatelessWidget {
           ),
         ],
       ),
-      footerBuilder: footerConfiguration.showFooter
-          ? (context) => FlutterDeckFooterTheme(
-                data: FlutterDeckFooterTheme.of(context).copyWith(
-                  slideNumberColor: theme.rightColor,
-                  socialHandleColor: theme.leftColor,
-                ),
-                child: FlutterDeckFooter.fromConfiguration(
-                  configuration: footerConfiguration,
-                ),
-              )
-          : null,
-      headerBuilder: headerConfiguration.showHeader
-          ? (context) => LayoutBuilder(
-                builder: (context, constraints) {
-                  final maxWidth = constraints.maxWidth *
-                      splitRatio.left /
-                      (splitRatio.left + splitRatio.right);
-
-                  return FlutterDeckHeaderTheme(
-                    data: FlutterDeckHeaderTheme.of(context).copyWith(
-                      color: theme.leftColor,
-                    ),
-                    child: FlutterDeckHeader.fromConfiguration(
-                      configuration: headerConfiguration,
-                      maxWidth: maxWidth,
-                    ),
-                  );
-                },
-              )
-          : null,
+      footerBuilder: footerConfiguration.showFooter ? _buildFooter : null,
+      headerBuilder: headerConfiguration.showHeader ? _buildHeader : null,
     );
   }
 }

--- a/lib/src/templates/title_slide.dart
+++ b/lib/src/templates/title_slide.dart
@@ -22,19 +22,22 @@ import 'package:flutter_deck/src/widgets/widgets.dart';
 ///
 /// To use a custom header, you can pass the [headerBuilder].
 ///
+/// To use a custom speaker info widget, you can pass the [speakerInfoBuilder].
+///
 /// This template uses the [FlutterDeckTitleSlideTheme] to style the slide.
 class FlutterDeckTitleSlide extends StatelessWidget {
   /// Creates a new title slide.
   ///
   /// The [title] argument must not be null. The [subtitle],
-  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
-  /// optional.
+  /// [backgroundBuilder], [footerBuilder], [headerBuilder], and
+  /// [speakerInfoBuilder] arguments are optional.
   const FlutterDeckTitleSlide({
     required this.title,
     this.subtitle,
     this.backgroundBuilder,
     this.footerBuilder,
     this.headerBuilder,
+    this.speakerInfoBuilder,
     super.key,
   });
 
@@ -55,6 +58,9 @@ class FlutterDeckTitleSlide extends StatelessWidget {
   /// A builder for the header of the slide.
   final WidgetBuilder? headerBuilder;
 
+  /// A builder for the speaker info part of the slide.
+  final WidgetBuilder? speakerInfoBuilder;
+
   Widget _buildFooter(BuildContext context) =>
       footerBuilder?.call(context) ??
       FlutterDeckFooter.fromConfiguration(
@@ -67,16 +73,24 @@ class FlutterDeckTitleSlide extends StatelessWidget {
         configuration: context.flutterDeck.configuration.header,
       );
 
+  Widget? _buildSpeakerInfo(BuildContext context) {
+    if (speakerInfoBuilder != null) return speakerInfoBuilder!(context);
+
+    final speakerInfo = context.flutterDeck.speakerInfo;
+
+    return speakerInfo != null
+        ? FlutterDeckSpeakerInfoWidget(speakerInfo: speakerInfo)
+        : null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckTitleSlideTheme.of(context);
-    final FlutterDeck(
-      configuration: FlutterDeckSlideConfiguration(
-        footer: footerConfiguration,
-        header: headerConfiguration,
-      ),
-      speakerInfo: speakerInfo,
-    ) = context.flutterDeck;
+    final FlutterDeckSlideConfiguration(
+      footer: footerConfiguration,
+      header: headerConfiguration,
+    ) = context.flutterDeck.configuration;
+    final speakerInfo = _buildSpeakerInfo(context);
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,
@@ -97,7 +111,7 @@ class FlutterDeckTitleSlide extends StatelessWidget {
             ],
             if (speakerInfo != null) ...[
               const SizedBox(height: 64),
-              FlutterDeckSpeakerInfoWidget(speakerInfo: speakerInfo),
+              speakerInfo,
             ],
           ],
         ),

--- a/lib/src/templates/title_slide.dart
+++ b/lib/src/templates/title_slide.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_deck/src/configuration/configuration.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
 import 'package:flutter_deck/src/flutter_deck_speaker_info.dart';
@@ -17,16 +18,23 @@ import 'package:flutter_deck/src/widgets/widgets.dart';
 ///
 /// To use a custom background, you can pass the [backgroundBuilder].
 ///
+/// To use a custom footer, you can pass the [footerBuilder].
+///
+/// To use a custom header, you can pass the [headerBuilder].
+///
 /// This template uses the [FlutterDeckTitleSlideTheme] to style the slide.
 class FlutterDeckTitleSlide extends StatelessWidget {
   /// Creates a new title slide.
   ///
-  /// The [title] argument must not be null. The [subtitle] and
-  /// [backgroundBuilder] arguments are optional.
+  /// The [title] argument must not be null. The [subtitle],
+  /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
+  /// optional.
   const FlutterDeckTitleSlide({
     required this.title,
     this.subtitle,
     this.backgroundBuilder,
+    this.footerBuilder,
+    this.headerBuilder,
     super.key,
   });
 
@@ -41,13 +49,34 @@ class FlutterDeckTitleSlide extends StatelessWidget {
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
 
+  /// A builder for the footer of the slide.
+  final WidgetBuilder? footerBuilder;
+
+  /// A builder for the header of the slide.
+  final WidgetBuilder? headerBuilder;
+
+  Widget _buildFooter(BuildContext context) =>
+      footerBuilder?.call(context) ??
+      FlutterDeckFooter.fromConfiguration(
+        configuration: context.flutterDeck.configuration.footer,
+      );
+
+  Widget _buildHeader(BuildContext context) =>
+      headerBuilder?.call(context) ??
+      FlutterDeckHeader.fromConfiguration(
+        configuration: context.flutterDeck.configuration.header,
+      );
+
   @override
   Widget build(BuildContext context) {
     final theme = FlutterDeckTitleSlideTheme.of(context);
-    final configuration = context.flutterDeck.configuration;
-    final footerConfiguration = configuration.footer;
-    final headerConfiguration = configuration.header;
-    final speakerInfo = context.flutterDeck.speakerInfo;
+    final FlutterDeck(
+      configuration: FlutterDeckSlideConfiguration(
+        footer: footerConfiguration,
+        header: headerConfiguration,
+      ),
+      speakerInfo: speakerInfo,
+    ) = context.flutterDeck;
 
     return FlutterDeckSlideBase(
       backgroundBuilder: backgroundBuilder,
@@ -73,16 +102,8 @@ class FlutterDeckTitleSlide extends StatelessWidget {
           ],
         ),
       ),
-      footerBuilder: footerConfiguration.showFooter
-          ? (context) => FlutterDeckFooter.fromConfiguration(
-                configuration: footerConfiguration,
-              )
-          : null,
-      headerBuilder: headerConfiguration.showHeader
-          ? (context) => FlutterDeckHeader.fromConfiguration(
-                configuration: headerConfiguration,
-              )
-          : null,
+      footerBuilder: footerConfiguration.showFooter ? _buildFooter : null,
+      headerBuilder: headerConfiguration.showHeader ? _buildHeader : null,
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

After introducing slide deck localisation, it is not possible to translate slide header, footer and speaker info components. This PR adds extra builders that could be used to override the default header/footer/speaker info builders and, if needed, translate them. 

As a side effect, this PR also resolves https://github.com/mkobuolys/flutter_deck/pull/68

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
