### PR TITLE
refactor: handle internal slide indexing in the router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+- refactor: handle internal slide indexing in the router
+
 # 0.13.0
 
 - feat: support header and footer builder overrides in slide templates

--- a/lib/src/controls/autoplay/flutter_deck_autoplay_notifier.dart
+++ b/lib/src/controls/autoplay/flutter_deck_autoplay_notifier.dart
@@ -55,9 +55,9 @@ class FlutterDeckAutoplayNotifier extends ChangeNotifier {
   }
 
   void _onNext(_) {
-    final configuration = _router.getCurrentSlideConfiguration();
-    final slideNumber = _router.getCurrentSlideIndex() + 1;
-    final stepNumber = _router.getCurrentStep();
+    final configuration = _router.currentSlideConfiguration;
+    final slideNumber = _router.currentSlideIndex + 1;
+    final stepNumber = _router.currentStep;
 
     final isLastSlide = slideNumber == _router.slides.length;
     final isLastStep = stepNumber == configuration.steps;

--- a/lib/src/flutter_deck.dart
+++ b/lib/src/flutter_deck.dart
@@ -117,17 +117,17 @@ class FlutterDeck extends InheritedWidget {
   void goToStep(int stepNumber) => _router.goToStep(stepNumber);
 
   /// Returns the current slide number.
-  int get slideNumber => _router.getCurrentSlideIndex() + 1;
+  int get slideNumber => _router.currentSlideIndex + 1;
 
   /// Returns the current step number.
-  int get stepNumber => _router.getCurrentStep();
+  int get stepNumber => _router.currentStep;
 
   /// Returns the speaker info.
   FlutterDeckSpeakerInfo? get speakerInfo => _speakerInfo;
 
   /// Returns the configuration for the current slide.
   FlutterDeckSlideConfiguration get configuration =>
-      _router.getCurrentSlideConfiguration();
+      _router.currentSlideConfiguration;
 
   /// Returns the global configuration for the slide deck.
   FlutterDeckConfiguration get globalConfiguration => _configuration;

--- a/lib/src/widgets/internal/drawer/flutter_deck_drawer.dart
+++ b/lib/src/widgets/internal/drawer/flutter_deck_drawer.dart
@@ -43,7 +43,7 @@ class _FlutterDeckDrawerState extends State<FlutterDeckDrawer> {
 
     if (viewHeight >= itemsCount * _navigationItemHeight) return 0;
 
-    final index = router.getCurrentSlideIndex();
+    final index = router.currentSlideIndex;
     final itemsInView = (viewHeight / _navigationItemHeight).floor();
 
     if (index < itemsInView / 2) return 0;


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The previous flutter_deck router handled routing based only on the current route. However, it complicates things when you need to handle routes without being in the route context. 

This PR adds internal slide indexing in the router so you can "change" routes without the actual route change in the browser or other platforms. This will be used internally for the presenter view, slide screenshots and other similar features where you need to access the slide directly through its index.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
