### PR TITLE
fix: keep State and Element when marker enabled

### DIFF
--- a/packages/flutter_deck/CHANGELOG.md
+++ b/packages/flutter_deck/CHANGELOG.md
@@ -1,6 +1,7 @@
 # NEXT
 
 - feat: add `textStyle` property to the `FlutterDeckCodeHighlight` widget
+- fix: keep the slide state when marker is toggled
 
 # 0.14.0
 

--- a/packages/flutter_deck/lib/src/widgets/internal/marker/flutter_deck_marker.dart
+++ b/packages/flutter_deck/lib/src/widgets/internal/marker/flutter_deck_marker.dart
@@ -37,14 +37,12 @@ class FlutterDeckMarker extends StatelessWidget {
     return ListenableBuilder(
       listenable: notifier,
       builder: (context, child) {
-        var widget = child!;
+        final paths = notifier.paths;
 
-        if (notifier.enabled) {
-          final paths = notifier.paths;
-
-          widget = Stack(
-            children: [
-              widget,
+        return Stack(
+          children: [
+            child!,
+            if (notifier.enabled)
               GestureDetector(
                 onPanStart: (details) => _updatePath(
                   context,
@@ -68,11 +66,8 @@ class FlutterDeckMarker extends StatelessWidget {
                   ),
                 ),
               ),
-            ],
-          );
-        }
-
-        return widget;
+          ],
+        );
       },
       child: child,
     );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

In the current version, State of `FlutterDeckSlide` is disposed and recreated when the marker is enabled/disabled. It is because the depth of `widget.child` is wrapped by `Stack` only when the feature is enabled, and the depth is changed by toggling the feature.

This PR changes the `widget.child` always inside `Stack`'s children, and not to change the depth of it.

### Before
![flutter_deck_before](https://github.com/mkobuolys/flutter_deck/assets/20849526/33b53fad-d886-4248-8a47-e975e86ff77f)

### After
![flutter_deck_after](https://github.com/mkobuolys/flutter_deck/assets/20849526/24c2cffb-949f-4464-af0c-14d03ebaceeb)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
