### PR TITLE
feat: allow passing AutoSizeGroup as a property to FlutterDeckBulletList

### DIFF
--- a/packages/flutter_deck/CHANGELOG.md
+++ b/packages/flutter_deck/CHANGELOG.md
@@ -1,8 +1,8 @@
 # NEXT
 
-- feat: allow passing AutoSizeGroup as a property to FlutterDeckBulletList
+- feat: allow passing `AutoSizeGroup` as a property to `FlutterDeckBulletList`
 - fix: header max width change on window resize
-- fix: FlutterDeckSlide.split slide alignment issues
+- fix: `FlutterDeckSlide.split` slide template alignment issues
 - chore: update go_router to v14.2.0
 - chore: update very_good_analysis to v6.0.0
 

--- a/packages/flutter_deck/CHANGELOG.md
+++ b/packages/flutter_deck/CHANGELOG.md
@@ -1,6 +1,8 @@
 # NEXT
 
+- feat: allow passing AutoSizeGroup as a property to FlutterDeckBulletList
 - fix: header max width change on window resize
+- fix: FlutterDeckSlide.split slide alignment issues
 - chore: update go_router to v14.2.0
 - chore: update very_good_analysis to v6.0.0
 

--- a/packages/flutter_deck/lib/src/templates/split_slide.dart
+++ b/packages/flutter_deck/lib/src/templates/split_slide.dart
@@ -132,6 +132,7 @@ class FlutterDeckSplitSlide extends StatelessWidget {
       backgroundBuilder: backgroundBuilder ??
           (context) => FlutterDeckBackground.custom(
                 child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     _BackgroundSection(
                       flex: splitRatio.left,
@@ -145,6 +146,7 @@ class FlutterDeckSplitSlide extends StatelessWidget {
                 ),
               ),
       contentBuilder: (context) => Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _ContentSection(
             flex: splitRatio.left,

--- a/packages/flutter_deck/lib/src/widgets/flutter_deck_bullet_list.dart
+++ b/packages/flutter_deck/lib/src/widgets/flutter_deck_bullet_list.dart
@@ -60,6 +60,7 @@ class FlutterDeckBulletList extends StatefulWidget {
     this.useSteps = false,
     this.stepOffset = 0,
     this.bulletPointWidget,
+    this.autoSizeGroup,
     super.key,
   }) : assert(items.isNotEmpty, 'You must provide at least one bullet point.');
 
@@ -87,12 +88,16 @@ class FlutterDeckBulletList extends StatefulWidget {
   /// A widget to use as the bullet point. If not provided, a dot will be used.
   final Widget? bulletPointWidget;
 
+  /// An optional [AutoSizeGroup] to use for the text sizing in the list. If not
+  /// provided, a new group will be created.
+  final AutoSizeGroup? autoSizeGroup;
+
   @override
   State<FlutterDeckBulletList> createState() => _FlutterDeckBulletListState();
 }
 
 class _FlutterDeckBulletListState extends State<FlutterDeckBulletList> {
-  final _autoSizeGroup = AutoSizeGroup();
+  late final _autoSizeGroup = widget.autoSizeGroup ?? AutoSizeGroup();
 
   @override
   Widget build(BuildContext context) {
@@ -132,6 +137,7 @@ class _BulletList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: [
         for (var i = 0; i < items.length; i++)
           Flexible(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Implements https://github.com/mkobuolys/flutter_deck/issues/89.
Also, fixes `FlutterDeckSlide.split` slide template alignment issues.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
