### PR TITLE
fix: gesture controls

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -15,6 +15,6 @@
     }
   ],
   "useGitignore": true,
-  "words": ["flutter_deck", "Mangirdas", "Kazlauskas"],
-  "ignorePaths": ["doc/website/source/showcase.md"]
+  "words": ["flutter_deck", "Mangirdas", "Kazlauskas", "subclassing"],
+  "ignorePaths": ["**/doc/website/source/showcase.md"]
 }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ FlutterDeckApp(
     ),
     controls: const FlutterDeckControlsConfiguration(
       presenterToolbarVisible: true,
+      gestures: FlutterDeckGesturesConfiguration.mobileOnly(),
       shortcuts: FlutterDeckShortcutsConfiguration(
         enabled: true,
         nextSlide: SingleActivator(LogicalKeyboardKey.arrowRight),

--- a/doc/website/source/get-started.md
+++ b/doc/website/source/get-started.md
@@ -52,6 +52,7 @@ FlutterDeckApp(
     ),
     controls: const FlutterDeckControlsConfiguration(
       presenterToolbarVisible: true,
+      gestures: FlutterDeckGesturesConfiguration.mobileOnly(),
       shortcuts: FlutterDeckShortcutsConfiguration(
         enabled: true,
         nextSlide: SingleActivator(LogicalKeyboardKey.arrowRight),

--- a/doc/website/source/playback/controls.md
+++ b/doc/website/source/playback/controls.md
@@ -2,7 +2,8 @@
 title: Controls
 navOrder: 1
 ---
-By default, every slide deck comes with a presenter toolbar that can be used to control the slide deck. Also, some of the controls can be accessed by using keyboard shortcuts.
+
+By default, every slide deck comes with a presenter toolbar that can be used to control the slide deck. Also, some of the controls can be accessed by using keyboard shortcuts or touch gestures.
 
 To disable all the controls (e.g. you use your own UI to control the slide deck), set the `controls` property for the slide deck configuration to `FlutterDeckControlsConfiguration.disabled()`:
 
@@ -24,12 +25,23 @@ FlutterDeckConfiguration(
 )
 ```
 
-To disable the keyboard shortcuts, set the `shortcuts` property to `FlutterDeckShortcutsConfiguration(enabled: false)`:
+To disable the keyboard shortcuts, set the `shortcuts` property to `FlutterDeckShortcutsConfiguration.disabled()`:
 
 ```dart
 FlutterDeckConfiguration(
   controls: const FlutterDeckControlsConfiguration(
-    shortcuts: FlutterDeckShortcutsConfiguration(enabled: false),
+    shortcuts: FlutterDeckShortcutsConfiguration.disabled(),
+  ),
+  <...>
+)
+```
+
+To disable the touch gestures, set the `gestures` property to `FlutterDeckGesturesConfiguration.disabled()`:
+
+```dart
+FlutterDeckConfiguration(
+  controls: const FlutterDeckControlsConfiguration(
+    gestures: FlutterDeckGesturesConfiguration.disabled(),
   ),
   <...>
 )

--- a/packages/flutter_deck/CHANGELOG.md
+++ b/packages/flutter_deck/CHANGELOG.md
@@ -1,3 +1,11 @@
+# NEXT
+
+- fix: show controls on tap on mobile devices (iOS and Android)
+- fix: controls are auto-hidden when the cursor is over them
+- feat: add swipe left/right gestures to navigate between slides
+- feat: add control gestures configuration
+- docs: update documentation website
+
 # 0.17.0
 
 - feat: allow using any widget as a slide

--- a/packages/flutter_deck/README.md
+++ b/packages/flutter_deck/README.md
@@ -88,6 +88,7 @@ FlutterDeckApp(
     ),
     controls: const FlutterDeckControlsConfiguration(
       presenterToolbarVisible: true,
+      gestures: FlutterDeckGesturesConfiguration.mobileOnly(),
       shortcuts: FlutterDeckShortcutsConfiguration(
         enabled: true,
         nextSlide: SingleActivator(LogicalKeyboardKey.arrowRight),

--- a/packages/flutter_deck/lib/src/configuration/flutter_deck_configuration.dart
+++ b/packages/flutter_deck/lib/src/configuration/flutter_deck_configuration.dart
@@ -38,8 +38,9 @@ class FlutterDeckConfiguration {
   /// for the [FlutterDeckSlide].
   final FlutterDeckBackgroundConfiguration background;
 
-  /// Configures the controls for the slide deck.  By default, the presenter
-  /// toolbar is visible and the default keyboard controls are enabled.
+  /// Configures the controls for the slide deck. By default, the presenter
+  /// toolbar is visible, the default keyboard controls are enabled, and
+  /// gestures are enabled on mobile platforms only.
   ///
   /// The default keyboard shortcuts are:
   /// - Next slide: \[ArrowRight\]

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_deck/src/controls/actions/actions.dart';
+import 'package:flutter_deck/src/controls/flutter_deck_controls_notifier.dart';
 import 'package:flutter_deck/src/controls/localized_shortcut_labeler.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
@@ -53,9 +54,9 @@ class FlutterDeckControls extends StatelessWidget {
         children: [
           child!,
           if (controlsNotifier.controlsVisible)
-            const Align(
+            Align(
               alignment: AlignmentDirectional.bottomCenter,
-              child: _Controls(),
+              child: _Controls(controlsNotifier: controlsNotifier),
             ),
         ],
       ),
@@ -65,29 +66,37 @@ class FlutterDeckControls extends StatelessWidget {
 }
 
 class _Controls extends StatelessWidget {
-  const _Controls();
+  const _Controls({
+    required this.controlsNotifier,
+  });
+
+  final FlutterDeckControlsNotifier controlsNotifier;
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data: ThemeData.light(),
-      child: Builder(
-        builder: (context) => Container(
-          margin: FlutterDeckLayout.slidePadding,
-          padding: const EdgeInsets.all(4),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(32),
-            color: Theme.of(context).colorScheme.surface,
-          ),
-          child: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _PreviousButton(),
-              _SlideNumberButton(),
-              _NextButton(),
-              _MarkerControls(),
-              _OptionsMenuButton(),
-            ],
+    return MouseRegion(
+      onEnter: (_) => controlsNotifier.toggleControlsVisibleDuration(),
+      onExit: (_) => controlsNotifier.toggleControlsVisibleDuration(),
+      child: Theme(
+        data: ThemeData.light(),
+        child: Builder(
+          builder: (context) => Container(
+            margin: FlutterDeckLayout.slidePadding,
+            padding: const EdgeInsets.all(4),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(32),
+              color: Theme.of(context).colorScheme.surface,
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _PreviousButton(),
+                _SlideNumberButton(),
+                _NextButton(),
+                _MarkerControls(),
+                _OptionsMenuButton(),
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls.dart
@@ -71,11 +71,11 @@ class _Controls extends StatelessWidget {
   Widget build(BuildContext context) {
     final controlsNotifier = context.flutterDeck.controlsNotifier;
 
-    return MouseRegion(
-      onEnter: (_) => controlsNotifier.toggleControlsVisibleDuration(),
-      onExit: (_) => controlsNotifier.toggleControlsVisibleDuration(),
-      child: Theme(
-        data: ThemeData.light(),
+    return Theme(
+      data: ThemeData.light(),
+      child: MouseRegion(
+        onEnter: (_) => controlsNotifier.toggleControlsVisibleDuration(),
+        onExit: (_) => controlsNotifier.toggleControlsVisibleDuration(),
         child: Builder(
           builder: (context) => Container(
             margin: FlutterDeckLayout.slidePadding,

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_deck/src/controls/actions/actions.dart';
-import 'package:flutter_deck/src/controls/flutter_deck_controls_notifier.dart';
 import 'package:flutter_deck/src/controls/localized_shortcut_labeler.dart';
 import 'package:flutter_deck/src/flutter_deck.dart';
 import 'package:flutter_deck/src/flutter_deck_layout.dart';
@@ -54,9 +53,9 @@ class FlutterDeckControls extends StatelessWidget {
         children: [
           child!,
           if (controlsNotifier.controlsVisible)
-            Align(
+            const Align(
               alignment: AlignmentDirectional.bottomCenter,
-              child: _Controls(controlsNotifier: controlsNotifier),
+              child: _Controls(),
             ),
         ],
       ),
@@ -66,14 +65,12 @@ class FlutterDeckControls extends StatelessWidget {
 }
 
 class _Controls extends StatelessWidget {
-  const _Controls({
-    required this.controlsNotifier,
-  });
-
-  final FlutterDeckControlsNotifier controlsNotifier;
+  const _Controls();
 
   @override
   Widget build(BuildContext context) {
+    final controlsNotifier = context.flutterDeck.controlsNotifier;
+
     return MouseRegion(
       onEnter: (_) => controlsNotifier.toggleControlsVisibleDuration(),
       onExit: (_) => controlsNotifier.toggleControlsVisibleDuration(),

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls_configuration.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls_configuration.dart
@@ -4,8 +4,8 @@ import 'package:flutter/widgets.dart';
 /// The configuration for the slide deck controls.
 class FlutterDeckControlsConfiguration {
   /// Creates a configuration for the slide deck controls. By default, the
-  /// presenter toolbar is visible and the default keyboard controls are
-  /// enabled.
+  /// presenter toolbar is visible, the default keyboard controls are
+  /// enabled, and gestures are enabled on mobile platforms only.
   ///
   /// The default keyboard shortcuts are:
   /// - Next slide: \[ArrowRight\]
@@ -19,20 +19,56 @@ class FlutterDeckControlsConfiguration {
   /// - [LogicalKeyboardKey] for a list of all available keys.
   const FlutterDeckControlsConfiguration({
     this.presenterToolbarVisible = true,
+    this.gestures = const FlutterDeckGesturesConfiguration.mobileOnly(),
     this.shortcuts = const FlutterDeckShortcutsConfiguration(),
   });
 
   /// Creates a configuration for the slide deck controls where they are
   /// disabled.
   const FlutterDeckControlsConfiguration.disabled()
-      : presenterToolbarVisible = false,
-        shortcuts = const FlutterDeckShortcutsConfiguration(enabled: false);
+      : this(
+          presenterToolbarVisible: false,
+          gestures: const FlutterDeckGesturesConfiguration.disabled(),
+          shortcuts: const FlutterDeckShortcutsConfiguration.disabled(),
+        );
 
   /// Whether the presenter toolbar is visible or not.
   final bool presenterToolbarVisible;
 
+  /// The configuration for the slide deck controls gestures.
+  final FlutterDeckGesturesConfiguration gestures;
+
   /// The configuration for the slide deck keyboard shortcuts.
   final FlutterDeckShortcutsConfiguration shortcuts;
+}
+
+/// The configuration for the slide deck control gestures.
+///
+/// The gesture controls are only available on [supportedPlatforms]. By default,
+/// gestures are enabled on all platforms.
+class FlutterDeckGesturesConfiguration {
+  /// Creates a configuration for the slide deck control gestures.
+  const FlutterDeckGesturesConfiguration({
+    this.supportedPlatforms = const {...TargetPlatform.values},
+  });
+
+  /// Creates a configuration for the slide deck control gestures where they are
+  /// disabled.
+  const FlutterDeckGesturesConfiguration.disabled()
+      : this(supportedPlatforms: const {});
+
+  /// Creates a configuration for the slide deck control gestures where they are
+  /// enabled on mobile platforms only.
+  const FlutterDeckGesturesConfiguration.mobileOnly()
+      : this(
+          supportedPlatforms: const {
+            TargetPlatform.android,
+            TargetPlatform.iOS,
+          },
+        );
+
+  /// The platforms where gestures are enabled.
+  final Set<TargetPlatform> supportedPlatforms;
 }
 
 /// The configuration for the slide deck keyboard shortcuts.
@@ -58,6 +94,10 @@ class FlutterDeckShortcutsConfiguration {
     this.toggleNavigationDrawer =
         const SingleActivator(LogicalKeyboardKey.period),
   });
+
+  /// Creates a configuration for the slide deck keyboard shortcuts where they
+  /// are disabled.
+  const FlutterDeckShortcutsConfiguration.disabled() : this(enabled: false);
 
   /// Whether keyboard shortcuts are enabled or not.
   final bool enabled;

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls_configuration.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls_configuration.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -69,6 +70,9 @@ class FlutterDeckGesturesConfiguration {
 
   /// The platforms where gestures are enabled.
   final Set<TargetPlatform> supportedPlatforms;
+
+  /// Whether gestures are enabled on the current platform or not.
+  bool get enabled => supportedPlatforms.contains(defaultTargetPlatform);
 }
 
 /// The configuration for the slide deck keyboard shortcuts.

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls_listener.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls_listener.dart
@@ -63,6 +63,17 @@ class FlutterDeckControlsListener extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controls = context.flutterDeck.globalConfiguration.controls;
+    final gesturesEnabled = controls.gestures.enabled;
+
+    Widget? gestureDetector(Widget? child) {
+      if (!gesturesEnabled) return child;
+
+      return GestureDetector(
+        onHorizontalDragEnd: _onHorizontalSwipe,
+        onTap: _onTap,
+        child: child,
+      );
+    }
 
     Widget widget = Focus(
       autofocus: true,
@@ -73,11 +84,7 @@ class FlutterDeckControlsListener extends StatelessWidget {
               ? MouseCursor.defer
               : SystemMouseCursors.none,
           onHover: _onMouseHover,
-          child: GestureDetector(
-            onHorizontalDragEnd: _onHorizontalSwipe,
-            onTap: _onTap,
-            child: child,
-          ),
+          child: gestureDetector(child),
         ),
         child: child,
       ),

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls_notifier.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls_notifier.dart
@@ -8,6 +8,8 @@ import 'package:flutter_deck/src/flutter_deck_router.dart';
 import 'package:flutter_deck/src/widgets/internal/drawer/drawer.dart';
 import 'package:flutter_deck/src/widgets/internal/marker/marker.dart';
 
+const _defaultControlsVisibleDuration = Duration(seconds: 3);
+
 /// The [ChangeNotifier] used to control the slide deck and handle cursor and
 /// deck controls visibility.
 class FlutterDeckControlsNotifier
@@ -33,6 +35,7 @@ class FlutterDeckControlsNotifier
   final FlutterDeckRouter _router;
 
   var _controlsVisible = false;
+  Duration _controlsVisibleDuration = _defaultControlsVisibleDuration;
   Timer? _controlsVisibleTimer;
 
   Set<Intent> _disabledIntents = {};
@@ -116,7 +119,7 @@ class FlutterDeckControlsNotifier
     _setControlsVisible(true);
 
     _controlsVisibleTimer = Timer(
-      const Duration(seconds: 3),
+      _controlsVisibleDuration,
       () => _setControlsVisible(false),
     );
   }
@@ -128,6 +131,16 @@ class FlutterDeckControlsNotifier
 
     _controlsVisible = visible;
     notifyListeners();
+  }
+
+  /// Toggle the cursor and controls visibility duration.
+  ///
+  /// The value toggles between 3 seconds and infinite (no auto-hide).
+  void toggleControlsVisibleDuration() {
+    _controlsVisibleDuration =
+        _controlsVisibleDuration > _defaultControlsVisibleDuration
+            ? _defaultControlsVisibleDuration
+            : const Duration(days: 1); // Infinite enough for this use case...
   }
 
   /// Whether the given [intent] is disabled.

--- a/packages/flutter_deck/lib/src/controls/flutter_deck_controls_notifier.dart
+++ b/packages/flutter_deck/lib/src/controls/flutter_deck_controls_notifier.dart
@@ -35,7 +35,7 @@ class FlutterDeckControlsNotifier
   final FlutterDeckRouter _router;
 
   var _controlsVisible = false;
-  Duration _controlsVisibleDuration = _defaultControlsVisibleDuration;
+  var _controlsVisibleDuration = _defaultControlsVisibleDuration;
   Timer? _controlsVisibleTimer;
 
   Set<Intent> _disabledIntents = {};

--- a/packages/flutter_deck/lib/src/flutter_deck_app.dart
+++ b/packages/flutter_deck/lib/src/flutter_deck_app.dart
@@ -271,6 +271,7 @@ class _FlutterDeckAppState extends State<FlutterDeckApp> {
               themeNotifier: _themeNotifier,
               child: FlutterDeckControlsListener(
                 controlsNotifier: _controlsNotifier,
+                markerNotifier: _markerNotifier,
                 child: FlutterDeckTheme(
                   data: theme,
                   child: child!,

--- a/packages/flutter_deck/lib/src/flutter_deck_app.dart
+++ b/packages/flutter_deck/lib/src/flutter_deck_app.dart
@@ -270,7 +270,7 @@ class _FlutterDeckAppState extends State<FlutterDeckApp> {
               presenterController: _presenterController,
               themeNotifier: _themeNotifier,
               child: FlutterDeckControlsListener(
-                notifier: _controlsNotifier,
+                controlsNotifier: _controlsNotifier,
                 child: FlutterDeckTheme(
                   data: theme,
                   child: child!,

--- a/packages/flutter_deck/lib/src/flutter_deck_slide.dart
+++ b/packages/flutter_deck/lib/src/flutter_deck_slide.dart
@@ -404,6 +404,7 @@ class FlutterDeckSlide extends FlutterDeckSlideWidget {
               notifier: context.flutterDeck.markerNotifier,
               child: Scaffold(
                 drawer: const FlutterDeckDrawer(),
+                drawerEnableOpenDragGesture: false,
                 body: _SlideBody(child: _builder(context)),
               ),
             ),


### PR DESCRIPTION
## Description

Fixes https://github.com/mkobuolys/flutter_deck/issues/118 and https://github.com/mkobuolys/flutter_deck/issues/111.

- Controls are visible by default on mobile devices (iOS and Android) on tap;
- Controls are not auto-hidden when the cursor is over them;
- Added swipe left/right gestures to switch between slides;
- Added `FlutterDeckGesturesConfiguration` to configure on which platforms the gesture controls are enabled;
- Updated documentation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
