### PR TITLE
fix: reset slides list and refresh Router when new slides provided to FlutterDeckApp to enable hot reloading of slides

### DIFF
--- a/packages/flutter_deck/lib/src/flutter_deck_app.dart
+++ b/packages/flutter_deck/lib/src/flutter_deck_app.dart
@@ -203,6 +203,25 @@ class _FlutterDeckAppState extends State<FlutterDeckApp> {
   }
 
   @override
+  void didUpdateWidget(covariant FlutterDeckApp oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (!listEquals(oldWidget.slides, widget.slides)) {
+      final slides = widget.slides
+          .where(_filterHidden)
+          .indexed
+          .map(_buildRouterSlide)
+          .toList();
+      _flutterDeckRouter.updateSlides(slides);
+      _router = _flutterDeckRouter.build(
+        isPresenterView: widget.isPresenterView,
+        navigatorObservers: widget.navigatorObservers,
+      );
+      setState(() {});
+    }
+  }
+
+  @override
   void dispose() {
     _presenterController.dispose();
 

--- a/packages/flutter_deck/lib/src/flutter_deck_router.dart
+++ b/packages/flutter_deck/lib/src/flutter_deck_router.dart
@@ -242,4 +242,24 @@ class FlutterDeckRouter extends ChangeNotifier {
       '${initialSlides.join(', ')}',
     );
   }
+
+  /// Update the list of slides.
+  ///
+  /// This method can be used to dynamically change the slides of the deck during
+  /// presentation or debugging.
+  /// 
+  /// If the new list of slides is the same as the current list, nothing happens.
+  /// When list is updated, the current slide and step are reset to the first slide and step.
+  void updateSlides(List<FlutterDeckRouterSlide> newSlides) {
+    if (listEquals(slides, newSlides)) return;
+
+    slides
+      ..clear()
+      ..addAll(newSlides);
+
+    _validateRoutes();
+
+    _currentSlideIndex = 0;
+    _currentSlideStep = 1;
+  }
 }


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This is super simple implementation of didUpdateWidget for FlutterDeckApp to enable hot reloading of slides.

It does not maintain the current position of the slides. It recreates the Router.

For me it makes it vastly easier to work on new slides without having to do hot restart.

https://github.com/user-attachments/assets/97120a1f-7638-457f-9d17-67398a474464




Fixes #151 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
