### PR TITLE
feat: export building blocks for custom slides

### DIFF
--- a/packages/flutter_deck/CHANGELOG.md
+++ b/packages/flutter_deck/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+- feat: export the building blocks needed to create custom slides
+  - `FlutterDeckLayout`, the built-in template widgets (e.g. `FlutterDeckBigFactSlide`, `FlutterDeckImageSlide`) and `AutoSizeText` are now exported from `package:flutter_deck/flutter_deck.dart`.
+
 # 0.29.0
 
 - feat: persist marker drawings per slide

--- a/packages/flutter_deck/lib/flutter_deck.dart
+++ b/packages/flutter_deck/lib/flutter_deck.dart
@@ -1,16 +1,20 @@
 /// The power of [Flutter](https://flutter.dev/), in your presentations.
 library;
 
+// Re-exported so that the code from the built-in slide templates can be copied
+// as-is when building custom slides.
+export 'package:auto_size_text/auto_size_text.dart';
+
 export 'src/configuration/configuration.dart';
 export 'src/controls/flutter_deck_shortcut.dart';
 export 'src/flutter_deck.dart';
 export 'src/flutter_deck_app.dart';
+export 'src/flutter_deck_layout.dart';
 export 'src/flutter_deck_slide.dart';
 export 'src/flutter_deck_speaker_info.dart';
 export 'src/plugins/plugins.dart';
 export 'src/renderers/renderers.dart';
-export 'src/templates/slide_base.dart';
-export 'src/templates/split_slide.dart' show SplitSlideRatio;
+export 'src/templates/templates.dart';
 export 'src/theme/flutter_deck_text_theme.dart';
 export 'src/theme/flutter_deck_theme.dart';
 export 'src/theme/templates/templates.dart';

--- a/packages/flutter_deck/test/src/templates/flutter_deck_slide_templates_test.dart
+++ b/packages/flutter_deck/test/src/templates/flutter_deck_slide_templates_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_deck/flutter_deck.dart';
 import 'package:flutter_deck/src/controls/controls.dart';
 import 'package:flutter_deck/src/flutter_deck_router.dart';
 import 'package:flutter_deck/src/presenter/presenter.dart';
-import 'package:flutter_deck/src/templates/templates.dart';
 import 'package:flutter_deck/src/theme/flutter_deck_theme_notifier.dart';
 import 'package:flutter_deck/src/widgets/internal/internal.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Description

Fixes #109.

When building a custom slide, it's natural to copy the `build` method of an existing built-in template and tweak it. Today that doesn't compile, because several symbols referenced by the templates aren't exported from `package:flutter_deck/flutter_deck.dart`.

This PR exports those building blocks:

- `FlutterDeckLayout` (used by **every** built-in template for `slidePadding`)
- the built-in template widgets themselves (`FlutterDeckBigFactSlide`, `FlutterDeckImageSlide`, `FlutterDeckTitleSlide`, `FlutterDeckQuoteSlide`, `FlutterDeckSplitSlide`, `FlutterDeckBlankSlide`) via the `templates` barrel
- `AutoSizeText` (re-exported from the `auto_size_text` dependency)

`FlutterDeckSlideBase`, the slide themes, headers/footers etc. were already exported, so a copied template `build` method now compiles as-is.

## Changes

- `lib/flutter_deck.dart`: add exports for `flutter_deck_layout.dart`, the full `templates/templates.dart` barrel, and re-export `package:auto_size_text/auto_size_text.dart`. This is purely additive (the previous selective template exports are a subset of the barrel).
- Removed a now-redundant internal `templates.dart` import in a test (the analyzer flags it as unnecessary once the barrel is public).

## Testing

- `dart analyze` clean.
- `flutter test`: all 206 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
