### PR TITLE
feat: support configurable fit and alignment on image slide

### DIFF
--- a/doc/website/source/slide-templates/image-slide.md
+++ b/doc/website/source/slide-templates/image-slide.md
@@ -28,3 +28,17 @@ class ImageSlide extends FlutterDeckSlideWidget {
 ```
 
 ![Image slide example](https://github.com/mkobuolys/flutter_deck/blob/main/images/templates/image.png?raw=true)
+
+## Controlling how the image is displayed
+
+By default, the image is scaled down to fit the available space (without ever being upscaled) and centered. You can change this with the `fit` and `alignment` arguments. For example, to make the image fill the whole slide (cropping it if needed) and align it to the top:
+
+```dart
+FlutterDeckSlide.image(
+  imageBuilder: (context) => Image.asset('assets/image.png'),
+  fit: BoxFit.cover,
+  alignment: Alignment.topCenter,
+);
+```
+
+`fit` accepts any `BoxFit` value (defaults to `BoxFit.scaleDown`) and `alignment` accepts any `AlignmentGeometry` value (defaults to `Alignment.center`).

--- a/packages/flutter_deck/CHANGELOG.md
+++ b/packages/flutter_deck/CHANGELOG.md
@@ -1,3 +1,10 @@
+## NEXT
+
+- feat: support configurable `fit` and `alignment` on `FlutterDeckSlide.image` and `FlutterDeckImageSlide`
+  - Defaults to `BoxFit.scaleDown` and `Alignment.center`, preserving the previous behavior.
+  - **BREAKING**: `FlutterDeckImageSlideBuilder` (used for `imageSlideBuilder` template overrides) now receives `BoxFit fit` and `AlignmentGeometry alignment` arguments after `label`.
+    - **Migration**: update the builder signature to `(context, imageBuilder, label, fit, alignment, backgroundBuilder, footerBuilder, headerBuilder)`.
+
 # 0.29.0
 
 - feat: persist marker drawings per slide

--- a/packages/flutter_deck/lib/src/configuration/flutter_deck_template_override_configuration.dart
+++ b/packages/flutter_deck/lib/src/configuration/flutter_deck_template_override_configuration.dart
@@ -29,6 +29,8 @@ typedef FlutterDeckImageSlideBuilder =
       BuildContext context,
       Image Function(BuildContext context) imageBuilder,
       String? label,
+      BoxFit fit,
+      AlignmentGeometry alignment,
       WidgetBuilder? backgroundBuilder,
       WidgetBuilder? footerBuilder,
       WidgetBuilder? headerBuilder,

--- a/packages/flutter_deck/lib/src/flutter_deck_slide.dart
+++ b/packages/flutter_deck/lib/src/flutter_deck_slide.dart
@@ -215,11 +215,17 @@ class FlutterDeckSlide extends FlutterDeckSlideWidget {
   /// [backgroundBuilder], [footerBuilder], and [headerBuilder] arguments are
   /// optional.
   ///
+  /// [fit] controls how the image is inscribed into the available space and
+  /// defaults to [BoxFit.scaleDown]. [alignment] controls how the image is
+  /// aligned within that space and defaults to [Alignment.center].
+  ///
   /// The passed [theme] will be merged with global [FlutterDeckTheme] data.
   FlutterDeckSlide.image({
     required ImageBuilder imageBuilder,
     FlutterDeckSlideConfiguration? configuration,
     String? label,
+    BoxFit fit = BoxFit.scaleDown,
+    AlignmentGeometry alignment = Alignment.center,
     WidgetBuilder? backgroundBuilder,
     WidgetBuilder? footerBuilder,
     WidgetBuilder? headerBuilder,
@@ -232,12 +238,23 @@ class FlutterDeckSlide extends FlutterDeckSlideWidget {
            final imageSlideBuilder = configuration.templateOverrides.imageSlideBuilder;
 
            if (imageSlideBuilder != null) {
-             return imageSlideBuilder(context, imageBuilder, label, backgroundBuilder, footerBuilder, headerBuilder);
+             return imageSlideBuilder(
+               context,
+               imageBuilder,
+               label,
+               fit,
+               alignment,
+               backgroundBuilder,
+               footerBuilder,
+               headerBuilder,
+             );
            }
 
            return FlutterDeckImageSlide(
              imageBuilder: imageBuilder,
              label: label,
+             fit: fit,
+             alignment: alignment,
              backgroundBuilder: backgroundBuilder,
              footerBuilder: footerBuilder,
              headerBuilder: headerBuilder,

--- a/packages/flutter_deck/lib/src/templates/image_slide.dart
+++ b/packages/flutter_deck/lib/src/templates/image_slide.dart
@@ -31,6 +31,8 @@ class FlutterDeckImageSlide extends StatelessWidget {
   const FlutterDeckImageSlide({
     required this.imageBuilder,
     this.label,
+    this.fit = BoxFit.scaleDown,
+    this.alignment = Alignment.center,
     this.backgroundBuilder,
     this.footerBuilder,
     this.headerBuilder,
@@ -44,6 +46,21 @@ class FlutterDeckImageSlide extends StatelessWidget {
   ///
   /// If this is null, no label will be displayed.
   final String? label;
+
+  /// How the image should be inscribed into the space allocated for it.
+  ///
+  /// Defaults to [BoxFit.scaleDown], which scales the image down to fit the
+  /// available space without ever upscaling it. Use [BoxFit.cover] to fill the
+  /// whole slide (cropping the image if needed), [BoxFit.contain] to scale the
+  /// image up or down to fit, etc.
+  final BoxFit fit;
+
+  /// How to align the image within the space allocated for it.
+  ///
+  /// This is relevant when the image does not fill the whole area, e.g. when
+  /// [fit] is [BoxFit.contain] or [BoxFit.scaleDown], or when the image is
+  /// cropped by [BoxFit.cover]. Defaults to [Alignment.center].
+  final AlignmentGeometry alignment;
 
   /// A builder for the background of the slide.
   final WidgetBuilder? backgroundBuilder;
@@ -74,7 +91,16 @@ class FlutterDeckImageSlide extends StatelessWidget {
         padding: FlutterDeckLayout.slidePadding,
         child: Column(
           children: [
-            Expanded(child: Center(child: imageBuilder(context))),
+            Expanded(
+              child: SizedBox.expand(
+                child: FittedBox(
+                  fit: fit,
+                  alignment: alignment,
+                  clipBehavior: Clip.hardEdge,
+                  child: imageBuilder(context),
+                ),
+              ),
+            ),
             if (label != null) ...[const SizedBox(height: 4), Text(label!, style: theme.labelTextStyle)],
           ],
         ),

--- a/packages/flutter_deck/test/src/flutter_deck_slide_test.dart
+++ b/packages/flutter_deck/test/src/flutter_deck_slide_test.dart
@@ -225,7 +225,7 @@ void main() {
         final overrideConfiguration = FlutterDeckTemplateOverrideConfiguration(
           bigFactSlideBuilder: (_, _, _, _, _, _, _) => const Text('Overridden Big Fact'),
           blankSlideBuilder: (_, _, _, _, _) => const Text('Overridden Blank'),
-          imageSlideBuilder: (_, _, _, _, _, _) => const Text('Overridden Image'),
+          imageSlideBuilder: (_, _, _, _, _, _, _, _) => const Text('Overridden Image'),
           quoteSlideBuilder: (_, _, _, _, _, _, _) => const Text('Overridden Quote'),
           splitSlideBuilder: (_, _, _, _, _, _, _) => const Text('Overridden Split'),
           templateSlideBuilder: (_, _, _, _, _) => const Text('Overridden Template'),

--- a/packages/flutter_deck/test/src/templates/flutter_deck_slide_templates_test.dart
+++ b/packages/flutter_deck/test/src/templates/flutter_deck_slide_templates_test.dart
@@ -106,6 +106,50 @@ void main() {
       expect(find.byType(Image), findsOneWidget);
       expect(find.text('Label'), findsOneWidget);
     });
+
+    testWidgets('applies default fit and alignment to the image', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FlutterDeckProvider(
+            flutterDeck: flutterDeck,
+            child: FlutterDeckTheme(
+              data: FlutterDeckThemeData.light(),
+              child: FlutterDeckImageSlide(imageBuilder: (context) => Image.memory(kTransparentImage)),
+            ),
+          ),
+        ),
+      );
+
+      final fittedBox = tester.widget<FittedBox>(
+        find.ancestor(of: find.byType(Image), matching: find.byType(FittedBox)),
+      );
+      expect(fittedBox.fit, BoxFit.scaleDown);
+      expect(fittedBox.alignment, Alignment.center);
+    });
+
+    testWidgets('forwards custom fit and alignment to the image', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FlutterDeckProvider(
+            flutterDeck: flutterDeck,
+            child: FlutterDeckTheme(
+              data: FlutterDeckThemeData.light(),
+              child: FlutterDeckImageSlide(
+                imageBuilder: (context) => Image.memory(kTransparentImage),
+                fit: BoxFit.cover,
+                alignment: Alignment.topLeft,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final fittedBox = tester.widget<FittedBox>(
+        find.ancestor(of: find.byType(Image), matching: find.byType(FittedBox)),
+      );
+      expect(fittedBox.fit, BoxFit.cover);
+      expect(fittedBox.alignment, Alignment.topLeft);
+    });
   });
 
   group('FlutterDeckQuoteSlide', () {


### PR DESCRIPTION
## Description

Fixes #107.

The image slide only ever shrank the image to fit and centered it, with no way to fill the slide (crop) or control alignment. This PR adds `fit` and `alignment` arguments to `FlutterDeckSlide.image` and `FlutterDeckImageSlide`.

```dart
FlutterDeckSlide.image(
  imageBuilder: (context) => Image.asset('assets/image.png'),
  fit: BoxFit.cover,
  alignment: Alignment.topCenter,
);
```

## Changes

- `FlutterDeckImageSlide` / `FlutterDeckSlide.image`: add `fit` (default `BoxFit.scaleDown`) and `alignment` (default `Alignment.center`). The image is now laid out with `SizedBox.expand` + `FittedBox`.
- Thread `fit` / `alignment` through the `FlutterDeckImageSlideBuilder` template-override typedef.
- Docs: document the new arguments in the image slide guide.
- Tests: add coverage for the default and custom `fit` / `alignment`.

## Behavior / breaking change

The default `BoxFit.scaleDown` reproduces the previous behavior exactly (the image is scaled down to fit, centered, and never upscaled), so existing decks look identical.

- **BREAKING**: `FlutterDeckImageSlideBuilder` now receives `BoxFit fit` and `AlignmentGeometry alignment` (after `label`). Only relevant if you provide a custom `imageSlideBuilder` template override. Migration: update the builder signature to `(context, imageBuilder, label, fit, alignment, backgroundBuilder, footerBuilder, headerBuilder)`.

## Testing

- `dart analyze` clean (package + example).
- `flutter test`: all 208 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
