### PR TITLE
feat: add flutter-deck-author agent skill (Markdown outline → slides)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ mason-lock.json
 
 # Agent related
 .agent
+
+# Superpowers (design specs, plans)
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ This repository ships [Agent Skills](https://agentskills.io) so AI coding agents
 | `flutter-deck-slides`             | Create slides using the eight built-in factories and three idiomatic patterns.                             |
 | `flutter-deck-theming`            | Style with `FlutterDeckThemeData`, light/dark modes, per-slide overrides, and component themes.            |
 | `flutter-deck-plugins`            | Build, register, and use `FlutterDeckPlugin`s — autoplay, exporters, presenter view, custom controls.      |
+| `flutter-deck-author`             | Generate a full deck from a Markdown outline — segment, map to factories, wire the barrel. |
 
 Skills are managed via the [`skills`](https://www.npmjs.com/package/skills) CLI.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This repository ships [Agent Skills](https://agentskills.io) so AI coding agents
 | `flutter-deck-slides`             | Create slides using the eight built-in factories and three idiomatic patterns.                             |
 | `flutter-deck-theming`            | Style with `FlutterDeckThemeData`, light/dark modes, per-slide overrides, and component themes.            |
 | `flutter-deck-plugins`            | Build, register, and use `FlutterDeckPlugin`s — autoplay, exporters, presenter view, custom controls.      |
-| `flutter-deck-author`             | Generate a full deck from a Markdown outline — segment, map to factories, wire the barrel. |
+| `flutter-deck-author`             | Generate a full deck from a Markdown outline — segment, map to factories, wire the barrel.                 |
 
 Skills are managed via the [`skills`](https://www.npmjs.com/package/skills) CLI.
 

--- a/README.md
+++ b/README.md
@@ -171,14 +171,14 @@ FlutterDeckApp(
 
 This repository ships [Agent Skills](https://agentskills.io) so AI coding agents (Claude Code, Cursor, Codex, OpenCode, Windsurf, and many [other compatible agents](https://agentskills.io/clients)) can help you build flutter_deck presentations accurately. Each skill captures the framework's conventions for a specific area:
 
-| Skill                             | Description                                                                                                |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `flutter-deck-presentation-setup` | Scaffold a new presentation from an empty Flutter project — `FlutterDeckApp`, themes, slides, plugins.     |
-| `flutter-deck-configuration`      | Configure a deck globally and per-slide — slide size, transitions, backgrounds, headers, footers.          |
-| `flutter-deck-slides`             | Create slides using the eight built-in factories and three idiomatic patterns.                             |
-| `flutter-deck-theming`            | Style with `FlutterDeckThemeData`, light/dark modes, per-slide overrides, and component themes.            |
-| `flutter-deck-plugins`            | Build, register, and use `FlutterDeckPlugin`s — autoplay, exporters, presenter view, custom controls.      |
-| `flutter-deck-author`             | Generate a full deck from a Markdown outline — segment, map to factories, wire the barrel.                 |
+| Skill                             | Description                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `flutter-deck-presentation-setup` | Scaffold a new presentation from an empty Flutter project — `FlutterDeckApp`, themes, slides, plugins. |
+| `flutter-deck-configuration`      | Configure a deck globally and per-slide — slide size, transitions, backgrounds, headers, footers.      |
+| `flutter-deck-slides`             | Create slides using the eight built-in factories and three idiomatic patterns.                         |
+| `flutter-deck-theming`            | Style with `FlutterDeckThemeData`, light/dark modes, per-slide overrides, and component themes.        |
+| `flutter-deck-plugins`            | Build, register, and use `FlutterDeckPlugin`s — autoplay, exporters, presenter view, custom controls.  |
+| `flutter-deck-author`             | Generate a full deck from a Markdown outline — segment, map to factories, wire the barrel.             |
 
 Skills are managed via the [`skills`](https://www.npmjs.com/package/skills) CLI.
 

--- a/doc/website/source/ai/agent-skills.md
+++ b/doc/website/source/ai/agent-skills.md
@@ -22,7 +22,7 @@ Six skills cover the surface area of `flutter_deck`. Each is scoped to a single 
 - **`flutter-deck-slides`** - Adding a new slide using one of the eight built-in factories (title, image, split, quote, bigFact, blank, template, custom).
 - **`flutter-deck-theming`** - Configuring `FlutterDeckThemeData`, light/dark modes, per-slide overrides, typography, or component-level themes.
 - **`flutter-deck-plugins`** - Building or wiring up `FlutterDeckPlugin`s - autoplay, PDF/PPTX export, the web client for the presenter view, custom controls.
-- **`flutter-deck-author`** - Generating a whole deck from a Markdown outline: segmenting into slides, mapping each block to the right factory, and wiring the `lib/slides/` barrel.
+- **`flutter-deck-author`** - Generating a whole deck from a Markdown outline: segmenting into slides, mapping each block to the right factory, and wiring the `lib/slides/` barrel. See [Authoring from Markdown](/ai/authoring-from-markdown/) for a full walkthrough.
 
 Each skill is a folder with a `SKILL.md` file living under [`skills/`](https://github.com/mkobuolys/flutter_deck/tree/main/skills) in the repository.
 

--- a/doc/website/source/ai/agent-skills.md
+++ b/doc/website/source/ai/agent-skills.md
@@ -15,13 +15,14 @@ Agent Skills are an open, vendor-neutral format. The skills shipped with `flutte
 
 ## Available skills
 
-Five skills cover the surface area of `flutter_deck`. Each is scoped to a single area so the agent loads only what's relevant to the task at hand.
+Six skills cover the surface area of `flutter_deck`. Each is scoped to a single area so the agent loads only what's relevant to the task at hand.
 
 - **`flutter-deck-presentation-setup`** - Scaffolding a new presentation, converting an empty Flutter project into a deck, or restructuring existing code.
 - **`flutter-deck-configuration`** - Defining `FlutterDeckConfiguration` or `FlutterDeckSlideConfiguration`, choosing transitions, slide size, controls, marker, etc.
 - **`flutter-deck-slides`** - Adding a new slide using one of the eight built-in factories (title, image, split, quote, bigFact, blank, template, custom).
 - **`flutter-deck-theming`** - Configuring `FlutterDeckThemeData`, light/dark modes, per-slide overrides, typography, or component-level themes.
 - **`flutter-deck-plugins`** - Building or wiring up `FlutterDeckPlugin`s - autoplay, PDF/PPTX export, the web client for the presenter view, custom controls.
+- **`flutter-deck-author`** - Generating a whole deck from a Markdown outline: segmenting into slides, mapping each block to the right factory, and wiring the `lib/slides/` barrel.
 
 Each skill is a folder with a `SKILL.md` file living under [`skills/`](https://github.com/mkobuolys/flutter_deck/tree/main/skills) in the repository.
 
@@ -39,7 +40,7 @@ This means you don't pay any context cost for skills you aren't using, and a sin
 
 Skills are managed via the [`skills`](https://www.npmjs.com/package/skills) CLI. Run the commands below from inside your `flutter_deck` project (or anywhere - they accept a project flag).
 
-### Install all five skills
+### Install all six skills
 
 ```sh
 npx skills add mkobuolys/flutter_deck --all

--- a/doc/website/source/ai/authoring-from-markdown.md
+++ b/doc/website/source/ai/authoring-from-markdown.md
@@ -52,22 +52,28 @@ title: Building Better Decks
 ---
 
 # Building Better Decks
+
 Slides as code, with flutter_deck
 
 ## Why slides as code?
+
 <!-- steps: reveal -->
+
 - Version control your entire talk
 - Reuse widgets and live demos
 - One framework, every platform
 
 ## 100%
+
 Flutter, all the way down
 
 ## In their words
+
 > The best presentation tool is the one you never fight.
-— A tired conference speaker
+> — A tired conference speaker
 
 ## Show me the code
+
 ```dart
 FlutterDeckApp(
   slides: [const TitleSlide()],
@@ -75,7 +81,9 @@ FlutterDeckApp(
 ```
 
 ## Thanks!
+
 <!-- slide: title -->
+
 Questions?
 ````
 
@@ -91,14 +99,14 @@ In your AI coding agent (Claude Code, Cursor, Codex, and other
 The agent creates one file per slide under `lib/slides/`, picking a template for each segment and
 deriving a route and class name from each heading:
 
-| Outline segment            | Slide template | Route                    | Class                     |
-| -------------------------- | -------------- | ------------------------ | ------------------------- |
-| `# Building Better Decks`  | title          | `/building-better-decks` | `BuildingBetterDecksSlide` |
-| `## Why slides as code?`   | content (bullets, revealed step by step) | `/why-slides-as-code` | `WhySlidesAsCodeSlide` |
-| `## 100%`                  | big fact       | `/100`                   | `Slide100`                |
-| `## In their words`        | quote          | `/in-their-words`        | `InTheirWordsSlide`       |
-| `## Show me the code`      | code           | `/show-me-the-code`      | `ShowMeTheCodeSlide`      |
-| `## Thanks!`               | title (forced) | `/thanks`                | `ThanksSlide`             |
+| Outline segment           | Slide template                           | Route                    | Class                      |
+| ------------------------- | ---------------------------------------- | ------------------------ | -------------------------- |
+| `# Building Better Decks` | title                                    | `/building-better-decks` | `BuildingBetterDecksSlide` |
+| `## Why slides as code?`  | content (bullets, revealed step by step) | `/why-slides-as-code`    | `WhySlidesAsCodeSlide`     |
+| `## 100%`                 | big fact                                 | `/100`                   | `Slide100`                 |
+| `## In their words`       | quote                                    | `/in-their-words`        | `InTheirWordsSlide`        |
+| `## Show me the code`     | code                                     | `/show-me-the-code`      | `ShowMeTheCodeSlide`       |
+| `## Thanks!`              | title (forced)                           | `/thanks`                | `ThanksSlide`              |
 
 For example, the `## Why slides as code?` segment — with its `<!-- steps: reveal -->` directive —
 becomes a slide whose bullet points appear one at a time:

--- a/doc/website/source/ai/authoring-from-markdown.md
+++ b/doc/website/source/ai/authoring-from-markdown.md
@@ -1,0 +1,165 @@
+---
+title: Authoring from Markdown
+navOrder: 2
+---
+
+# Generating a deck from a Markdown outline
+
+Writing every slide by hand is the slow part of building a presentation. With the
+[`flutter-deck-author`](/ai/agent-skills/) skill installed, you can write your talk as a plain
+Markdown outline and let an AI agent turn it into idiomatic `flutter_deck` slides — one Dart file
+per slide, wired into your deck.
+
+The skill is **content-only**: it generates slides, but it does not scaffold the app or define
+themes. If you don't have a deck yet, the agent will set one up first (via the
+`flutter-deck-presentation-setup` skill), then generate your slides into it.
+
+## 1. Install the skill
+
+The authoring skill ships with `flutter_deck`. Install it into your project like any other skill
+(see [Agent Skills](/ai/agent-skills/) for details):
+
+```sh
+npx skills add mkobuolys/flutter_deck --skill flutter-deck-author
+```
+
+## 2. Write an outline
+
+Create a Markdown file — say `outline.md` — that describes your talk. You write normal Markdown;
+the skill maps its **shape** to the right slide template:
+
+- The top `#` heading becomes the opening **title** slide.
+- Each `##` heading starts a new slide.
+- A blockquote (`>`) becomes a **quote** slide.
+- A short stat heading (like `## 100%`) becomes a **big fact** slide.
+- A fenced code block becomes a **code** slide with syntax highlighting.
+- An image becomes an **image** slide; text next to an image or code becomes a **split** slide.
+- A heading with a bullet list becomes a **content** slide.
+
+You can also drop in HTML-comment directives to override the defaults — they're invisible when the
+Markdown is rendered anywhere else:
+
+- `<!-- slide: title -->` — force a specific template for this slide.
+- `<!-- steps: reveal -->` — reveal bullet points one at a time.
+- `<!-- notes: ... -->` — attach speaker notes.
+- `<!-- route: /custom -->` — set an explicit route.
+
+Here's a complete example outline:
+
+````markdown
+---
+title: Building Better Decks
+---
+
+# Building Better Decks
+Slides as code, with flutter_deck
+
+## Why slides as code?
+<!-- steps: reveal -->
+- Version control your entire talk
+- Reuse widgets and live demos
+- One framework, every platform
+
+## 100%
+Flutter, all the way down
+
+## In their words
+> The best presentation tool is the one you never fight.
+— A tired conference speaker
+
+## Show me the code
+```dart
+FlutterDeckApp(
+  slides: [const TitleSlide()],
+);
+```
+
+## Thanks!
+<!-- slide: title -->
+Questions?
+````
+
+## 3. Ask your agent to generate the deck
+
+In your AI coding agent (Claude Code, Cursor, Codex, and other
+[compatible clients](https://agentskills.io/clients)), point it at the outline:
+
+> Using the flutter-deck-author skill, generate slides from `outline.md` and wire them into my deck.
+
+## 4. What you get
+
+The agent creates one file per slide under `lib/slides/`, picking a template for each segment and
+deriving a route and class name from each heading:
+
+| Outline segment            | Slide template | Route                    | Class                     |
+| -------------------------- | -------------- | ------------------------ | ------------------------- |
+| `# Building Better Decks`  | title          | `/building-better-decks` | `BuildingBetterDecksSlide` |
+| `## Why slides as code?`   | content (bullets, revealed step by step) | `/why-slides-as-code` | `WhySlidesAsCodeSlide` |
+| `## 100%`                  | big fact       | `/100`                   | `Slide100`                |
+| `## In their words`        | quote          | `/in-their-words`        | `InTheirWordsSlide`       |
+| `## Show me the code`      | code           | `/show-me-the-code`      | `ShowMeTheCodeSlide`      |
+| `## Thanks!`               | title (forced) | `/thanks`                | `ThanksSlide`             |
+
+For example, the `## Why slides as code?` segment — with its `<!-- steps: reveal -->` directive —
+becomes a slide whose bullet points appear one at a time:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_deck/flutter_deck.dart';
+
+class WhySlidesAsCodeSlide extends FlutterDeckSlideWidget {
+  const WhySlidesAsCodeSlide()
+    : super(
+        configuration: const FlutterDeckSlideConfiguration(
+          route: '/why-slides-as-code',
+          title: 'Why slides as code?',
+          header: FlutterDeckHeaderConfiguration(title: 'Why slides as code?'),
+          steps: 3,
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return FlutterDeckSlide.blank(
+      builder: (context) => FlutterDeckBulletList(
+        useSteps: true,
+        items: const [
+          'Version control your entire talk',
+          'Reuse widgets and live demos',
+          'One framework, every platform',
+        ],
+      ),
+    );
+  }
+}
+```
+
+The agent also updates the `lib/slides/slides.dart` barrel and adds the slides — in outline order —
+to your `FlutterDeckApp`:
+
+```dart
+slides: const [
+  BuildingBetterDecksSlide(),
+  WhySlidesAsCodeSlide(),
+  Slide100(),
+  InTheirWordsSlide(),
+  ShowMeTheCodeSlide(),
+  ThanksSlide(),
+],
+```
+
+Run the app and you have a working deck — ready to refine slide by slide.
+
+## Tips
+
+- **Iterate on the outline, not the Dart.** Re-running the skill on an updated outline is the
+  fastest way to reshape a talk. Drop to hand-written slides only when a slide needs custom widgets.
+- **Reach for directives sparingly.** The heuristics cover most slides; use `<!-- slide: ... -->`
+  only when you want a template the content shape wouldn't pick on its own.
+- **Style comes later.** The generated slides inherit your deck's theme. See
+  [Theming](/guides/theming/) to brand them, and pair the authoring skill with the
+  `flutter-deck-theming` skill.
+
+For the full mapping rules, directive reference, and naming conventions, see the skill itself under
+[`skills/flutter-deck-author/`](https://github.com/mkobuolys/flutter_deck/tree/main/skills/flutter-deck-author)
+or the [Agent Skills](/ai/agent-skills/) overview.

--- a/doc/website/source/ai/authoring-from-markdown.md
+++ b/doc/website/source/ai/authoring-from-markdown.md
@@ -97,16 +97,17 @@ In your AI coding agent (Claude Code, Cursor, Codex, and other
 ## 4. What you get
 
 The agent creates one file per slide under `lib/slides/`, picking a template for each segment and
-deriving a route and class name from each heading:
+deriving a route and class name from each heading. For the outline above, that's six slides:
 
-| Outline segment           | Slide template                           | Route                    | Class                      |
-| ------------------------- | ---------------------------------------- | ------------------------ | -------------------------- |
-| `# Building Better Decks` | title                                    | `/building-better-decks` | `BuildingBetterDecksSlide` |
-| `## Why slides as code?`  | content (bullets, revealed step by step) | `/why-slides-as-code`    | `WhySlidesAsCodeSlide`     |
-| `## 100%`                 | big fact                                 | `/100`                   | `Slide100`                 |
-| `## In their words`       | quote                                    | `/in-their-words`        | `InTheirWordsSlide`        |
-| `## Show me the code`     | code                                     | `/show-me-the-code`      | `ShowMeTheCodeSlide`       |
-| `## Thanks!`              | title (forced)                           | `/thanks`                | `ThanksSlide`              |
+- **`# Building Better Decks`** → **title** slide — route `/building-better-decks`, class
+  `BuildingBetterDecksSlide`
+- **`## Why slides as code?`** → **content** slide with bullets revealed step by step — route
+  `/why-slides-as-code`, class `WhySlidesAsCodeSlide`
+- **`## 100%`** → **big fact** slide — route `/100`, class `Slide100`
+- **`## In their words`** → **quote** slide — route `/in-their-words`, class `InTheirWordsSlide`
+- **`## Show me the code`** → **code** slide — route `/show-me-the-code`, class `ShowMeTheCodeSlide`
+- **`## Thanks!`** → **title** slide, forced with `` `<!-- slide: title -->` `` — route `/thanks`,
+  class `ThanksSlide`
 
 For example, the `## Why slides as code?` segment — with its `<!-- steps: reveal -->` directive —
 becomes a slide whose bullet points appear one at a time:

--- a/skills/flutter-deck-author/SKILL.md
+++ b/skills/flutter-deck-author/SKILL.md
@@ -71,25 +71,26 @@ block and wiring the barrel. It is **content-only**:
 
 Pick the factory from the **shape** of the segment's content:
 
-| Segment shape                                   | Factory                                                          |
-| ----------------------------------------------- | ---------------------------------------------------------------- |
-| First slide / a lone H1                         | `FlutterDeckSlide.title` (subtitle from the next line or an H2)  |
-| A dominant blockquote (`>`)                     | `FlutterDeckSlide.quote` (attribution from a `— name` line)      |
-| A short stat heading (e.g. `## 100%`)           | `FlutterDeckSlide.bigFact` (subtitle = the following line)       |
-| A dominant fenced code block                    | `FlutterDeckSlide.blank` + `FlutterDeckCodeHighlight`            |
-| A lone image `![alt](path)`                     | `FlutterDeckSlide.image` (label = alt); add path to `preloadImages` |
-| Text **and** an image/code block together       | `FlutterDeckSlide.split` (text left, media right)                |
-| Heading + bullet list (**default**)             | `FlutterDeckSlide.blank` + `FlutterDeckBulletList`               |
-| Empty / unrecognized                            | `FlutterDeckSlide.blank`                                          |
+| Segment shape                             | Factory                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------- |
+| First slide / a lone H1                   | `FlutterDeckSlide.title` (subtitle from the next line or an H2)     |
+| A dominant blockquote (`>`)               | `FlutterDeckSlide.quote` (attribution from a `— name` line)         |
+| A short stat heading (e.g. `## 100%`)     | `FlutterDeckSlide.bigFact` (subtitle = the following line)          |
+| A dominant fenced code block              | `FlutterDeckSlide.blank` + `FlutterDeckCodeHighlight`               |
+| A lone image `![alt](path)`               | `FlutterDeckSlide.image` (label = alt); add path to `preloadImages` |
+| Text **and** an image/code block together | `FlutterDeckSlide.split` (text left, media right)                   |
+| Heading + bullet list (**default**)       | `FlutterDeckSlide.blank` + `FlutterDeckBulletList`                  |
+| Empty / unrecognized                      | `FlutterDeckSlide.blank`                                            |
 
 Notes:
+
 - **Precedence:** evaluate the rows top-to-bottom and use the first that
   matches; the bottom two rows are fallbacks. A `<!-- slide: -->` directive
   always overrides the heuristic. If a segment genuinely matches two specific
   rows (e.g. text with both an image and a fenced code block), prefer `split`
   or add an explicit `<!-- slide: -->`.
 - A bulleted content slide sets `header: FlutterDeckHeaderConfiguration(title:
-  <heading>)` so the section title shows above the bullets.
+<heading>)` so the section title shows above the bullets.
 - Code slides: wrap `FlutterDeckCodeHighlight` in a `Center`. Language comes
   from the fence info string; `FlutterDeckCodeHighlight` defaults to
   `language: 'dart'`, so omit `language:` when the fence is `dart`, otherwise
@@ -102,12 +103,12 @@ Notes:
 HTML comments are invisible in rendered Markdown, so the source stays a normal
 document. Place a directive inside the slide's segment.
 
-| Directive                     | Effect                                                                 |
-| ----------------------------- | ---------------------------------------------------------------------- |
-| `<!-- slide: <factory> -->`   | Force the factory (e.g. `split`, `bigFact`, `quote`, `title`).         |
-| `<!-- steps: reveal -->`      | Reveal bullets one-by-one: `FlutterDeckBulletList(useSteps: true)` and set `steps:` to the bullet count. |
-| `<!-- notes: … -->`           | Becomes the slide's `speakerNotes`.                                     |
-| `<!-- route: /custom -->`     | Override the derived route.                                             |
+| Directive                   | Effect                                                                                                   |
+| --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `<!-- slide: <factory> -->` | Force the factory (e.g. `split`, `bigFact`, `quote`, `title`).                                           |
+| `<!-- steps: reveal -->`    | Reveal bullets one-by-one: `FlutterDeckBulletList(useSteps: true)` and set `steps:` to the bullet count. |
+| `<!-- notes: … -->`         | Becomes the slide's `speakerNotes`.                                                                      |
+| `<!-- route: /custom -->`   | Override the derived route.                                                                              |
 
 ## Deriving Routes and Class Names
 
@@ -139,22 +140,28 @@ title: Building Better Decks
 ---
 
 # Building Better Decks
+
 Slides as code, with flutter_deck
 
 ## Why slides as code?
+
 <!-- steps: reveal -->
+
 - Version control your entire talk
 - Reuse widgets and live demos
 - One framework, every platform
 
 ## 100%
+
 Flutter, all the way down
 
 ## In their words
+
 > The best presentation tool is the one you never fight.
-— A tired conference speaker
+> — A tired conference speaker
 
 ## Show me the code
+
 ```dart
 FlutterDeckApp(
   slides: [const TitleSlide()],
@@ -162,7 +169,9 @@ FlutterDeckApp(
 ```
 
 ## Thanks!
+
 <!-- slide: title -->
+
 Questions?
 ````
 

--- a/skills/flutter-deck-author/SKILL.md
+++ b/skills/flutter-deck-author/SKILL.md
@@ -37,7 +37,8 @@ block and wiring the barrel. It is **content-only**:
 
 - The user provides a Markdown outline / notes and wants slides.
 - The user asks to "make a deck about X" or "draft a talk on Y" — draft an
-  `outline.md` first (see Step 1), get approval, then generate from it.
+  `outline.md` first (see the Pipeline Checklist below), get approval, then
+  generate from it.
 - The user wants to bulk-create many slides at once rather than one at a time.
 
 ## Pipeline Checklist
@@ -89,8 +90,12 @@ Notes:
   or add an explicit `<!-- slide: -->`.
 - A bulleted content slide sets `header: FlutterDeckHeaderConfiguration(title:
   <heading>)` so the section title shows above the bullets.
-- Code slides: language comes from the fence info string (```` ```dart ````);
-  `FlutterDeckCodeHighlight` defaults to `language: 'dart'`.
+- Code slides: wrap `FlutterDeckCodeHighlight` in a `Center`. Language comes
+  from the fence info string; `FlutterDeckCodeHighlight` defaults to
+  `language: 'dart'`, so omit `language:` when the fence is `dart`, otherwise
+  pass it explicitly.
+- Quote attribution: keep the source attribution text verbatim, including any
+  leading `—`.
 
 ## Override Directives
 
@@ -114,6 +119,10 @@ document. Place a directive inside the slide's segment.
   (`Why slides as code?` → `WhySlidesAsCodeSlide`). If that would start with a
   digit (a stat heading like `100%`), use `Slide` + the digits instead
   (`Slide100`). Empty → `Slide<index>`.
+- **Title:** always set `title:` in the slide configuration to the heading
+  text, so the navigation drawer shows a readable label instead of falling
+  back to the route. Slides without a heading (e.g. a lone stat) still set
+  it — `title: '100%'`.
 - **File name:** snake_case of the class name (`WhySlidesAsCodeSlide` →
   `why_slides_as_code_slide.dart`; `Slide100` → `slide100.dart`).
 - **Barrel order:** order the `export` statements alphabetically (Dart's
@@ -204,7 +213,10 @@ import 'package:flutter_deck/flutter_deck.dart';
 class Slide100 extends FlutterDeckSlideWidget {
   const Slide100()
     : super(
-        configuration: const FlutterDeckSlideConfiguration(route: '/100'),
+        configuration: const FlutterDeckSlideConfiguration(
+          route: '/100',
+          title: '100%',
+        ),
       );
 
   @override

--- a/skills/flutter-deck-author/SKILL.md
+++ b/skills/flutter-deck-author/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: flutter-deck-author
+description: >
+  Generate a flutter_deck presentation from a Markdown outline — turn talk
+  notes, an outline, or a topic into idiomatic slide files. Segments Markdown
+  into slides, maps each block to the right built-in factory (title, quote,
+  bigFact, image, split, code, bulleted content) by content shape, honors
+  per-slide override directives (`<!-- slide: -->`, `<!-- steps: reveal -->`,
+  `<!-- notes: -->`, `<!-- route: -->`), derives routes and class names, and
+  wires the `lib/slides/` barrel. Use when authoring or drafting a deck from
+  Markdown, bulk-creating slides from an outline, or converting notes into a
+  flutter_deck presentation — even when the user only says "make a deck about
+  X" or "turn this outline into slides". Composes with
+  flutter-deck-presentation-setup (app wiring) and flutter-deck-slides /
+  flutter-deck-theming (factory and styling details).
+compatibility: >
+  Requires a Flutter project with the flutter_deck package added as a
+  dependency.
+---
+
+# Authoring a Flutter Deck from Markdown
+
+## Overview
+
+This skill turns a Markdown outline into idiomatic `flutter_deck` slide files.
+The author writes content in Markdown; the agent emits one Dart file per slide
+under `lib/slides/`, choosing the right `FlutterDeckSlide` factory for each
+block and wiring the barrel. It is **content-only**:
+
+- It does **not** scaffold `FlutterDeckApp`, add the dependency, or define
+  themes. If the project has no deck yet, use **flutter-deck-presentation-setup**
+  first, then return here.
+- For the details of each factory or for styling, defer to
+  **flutter-deck-slides** and **flutter-deck-theming**.
+
+## When to Use This Skill
+
+- The user provides a Markdown outline / notes and wants slides.
+- The user asks to "make a deck about X" or "draft a talk on Y" — draft an
+  `outline.md` first (see Step 1), get approval, then generate from it.
+- The user wants to bulk-create many slides at once rather than one at a time.
+
+## Pipeline Checklist
+
+- [ ] Obtain the Markdown source (a file, pasted text, or a drafted `outline.md`
+      the user approved).
+- [ ] Confirm a `FlutterDeckApp` exists. If not, hand off to
+      **flutter-deck-presentation-setup**, then resume.
+- [ ] Detect the target layout: flat `lib/slides/` vs. grouped section barrels.
+      Match whatever the deck already uses; default to flat `lib/slides/`.
+- [ ] Segment the Markdown into slides (rules below).
+- [ ] Classify each segment into a factory (heuristics + directives below).
+- [ ] Emit one Dart file per slide; derive the route and class name.
+- [ ] Update `lib/slides/slides.dart` (and section arrays if grouped).
+- [ ] Add the slides to `FlutterDeckApp.slides` if that list is discoverable;
+      otherwise print the exact lines to paste.
+- [ ] Post-checks: unique routes; `preloadImages` set for every image; remind
+      the user to check contrast/overflow (see flutter-deck-theming).
+
+## Segmenting Markdown into Slides
+
+- A top-level `#` (H1) at the start becomes the deck's opening **title** slide.
+- A `---` horizontal rule is a hard slide break.
+- Otherwise each `##` (H2) starts a new slide; the H2 text is that slide's
+  title and the source of its route/class name.
+- Optional YAML frontmatter at the top carries deck-level metadata (e.g.
+  `title:`); it does not itself produce a slide.
+
+## Mapping Content to Factories (heuristics)
+
+Pick the factory from the **shape** of the segment's content:
+
+| Segment shape                                   | Factory                                                          |
+| ----------------------------------------------- | ---------------------------------------------------------------- |
+| First slide / a lone H1                         | `FlutterDeckSlide.title` (subtitle from the next line or an H2)  |
+| A dominant blockquote (`>`)                     | `FlutterDeckSlide.quote` (attribution from a `— name` line)      |
+| A short stat heading (e.g. `## 100%`)           | `FlutterDeckSlide.bigFact` (subtitle = the following line)       |
+| A dominant fenced code block                    | `FlutterDeckSlide.blank` + `FlutterDeckCodeHighlight`            |
+| A lone image `![alt](path)`                     | `FlutterDeckSlide.image` (label = alt); add path to `preloadImages` |
+| Text **and** an image/code block together       | `FlutterDeckSlide.split` (text left, media right)                |
+| Heading + bullet list (**default**)             | `FlutterDeckSlide.blank` + `FlutterDeckBulletList`               |
+| Empty / unrecognized                            | `FlutterDeckSlide.blank`                                          |
+
+Notes:
+- A bulleted content slide sets `header: FlutterDeckHeaderConfiguration(title:
+  <heading>)` so the section title shows above the bullets.
+- Code slides: language comes from the fence info string (```` ```dart ````);
+  `FlutterDeckCodeHighlight` defaults to `language: 'dart'`.
+
+## Override Directives
+
+HTML comments are invisible in rendered Markdown, so the source stays a normal
+document. Place a directive inside the slide's segment.
+
+| Directive                     | Effect                                                                 |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `<!-- slide: <factory> -->`   | Force the factory (e.g. `split`, `bigFact`, `quote`, `title`).         |
+| `<!-- steps: reveal -->`      | Reveal bullets one-by-one: `FlutterDeckBulletList(useSteps: true)` and set `steps:` to the bullet count. |
+| `<!-- notes: … -->`           | Becomes the slide's `speakerNotes`.                                     |
+| `<!-- route: /custom -->`     | Override the derived route.                                             |
+
+## Deriving Routes and Class Names
+
+- **Route:** `/` + a slug of the heading (lowercase; each run of non-alphanumeric
+  characters becomes a single `-`; trim leading/trailing `-`). Empty slug →
+  `/slide-<index>`. A `<!-- route: -->` directive always wins. On collision,
+  append `-<index>`.
+- **Class:** PascalCase of the heading's alphanumeric words + `Slide`
+  (`Why slides as code?` → `WhySlidesAsCodeSlide`). If that would start with a
+  digit (a stat heading like `100%`), use `Slide` + the digits instead
+  (`Slide100`). Empty → `Slide<index>`.
+- **File name:** snake_case of the class name (`WhySlidesAsCodeSlide` →
+  `why_slides_as_code_slide.dart`; `Slide100` → `slide100.dart`).
+
+## Worked Example
+
+Input `outline.md`:
+
+````markdown
+---
+title: Building Better Decks
+---
+
+# Building Better Decks
+Slides as code, with flutter_deck
+
+## Why slides as code?
+<!-- steps: reveal -->
+- Version control your entire talk
+- Reuse widgets and live demos
+- One framework, every platform
+
+## 100%
+Flutter, all the way down
+
+## In their words
+> The best presentation tool is the one you never fight.
+— A tired conference speaker
+
+## Show me the code
+```dart
+FlutterDeckApp(
+  slides: [const TitleSlide()],
+);
+```
+
+## Thanks!
+<!-- slide: title -->
+Questions?
+````
+
+This produces six files under `lib/slides/` (title, stepped bullet list,
+bigFact, quote, code, forced-title), each subclassing `FlutterDeckSlideWidget`.
+Two representative outputs:
+
+`lib/slides/why_slides_as_code_slide.dart` (heading + bullets + `steps: reveal`):
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_deck/flutter_deck.dart';
+
+class WhySlidesAsCodeSlide extends FlutterDeckSlideWidget {
+  const WhySlidesAsCodeSlide()
+    : super(
+        configuration: const FlutterDeckSlideConfiguration(
+          route: '/why-slides-as-code',
+          title: 'Why slides as code?',
+          header: FlutterDeckHeaderConfiguration(title: 'Why slides as code?'),
+          steps: 3,
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return FlutterDeckSlide.blank(
+      builder: (context) => FlutterDeckBulletList(
+        useSteps: true,
+        items: const [
+          'Version control your entire talk',
+          'Reuse widgets and live demos',
+          'One framework, every platform',
+        ],
+      ),
+    );
+  }
+}
+```
+
+`lib/slides/slide100.dart` (short stat heading → bigFact; digit-leading class →
+`Slide` prefix):
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_deck/flutter_deck.dart';
+
+class Slide100 extends FlutterDeckSlideWidget {
+  const Slide100()
+    : super(
+        configuration: const FlutterDeckSlideConfiguration(route: '/100'),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return FlutterDeckSlide.bigFact(
+      title: '100%',
+      subtitle: 'Flutter, all the way down',
+    );
+  }
+}
+```
+
+Barrel `lib/slides/slides.dart`:
+
+```dart
+export 'building_better_decks_slide.dart';
+export 'in_their_words_slide.dart';
+export 'show_me_the_code_slide.dart';
+export 'slide100.dart';
+export 'thanks_slide.dart';
+export 'why_slides_as_code_slide.dart';
+```
+
+Then add the slides (in outline order) to `FlutterDeckApp.slides`:
+
+```dart
+slides: const [
+  BuildingBetterDecksSlide(),
+  WhySlidesAsCodeSlide(),
+  Slide100(),
+  InTheirWordsSlide(),
+  ShowMeTheCodeSlide(),
+  ThanksSlide(),
+],
+```
+
+## Gotchas
+
+- Order in `FlutterDeckApp.slides` **is** the presentation order — add slides in
+  outline order.
+- A slide only renders if it is in `FlutterDeckApp.slides`. Creating the file
+  and exporting it from the barrel is not enough.
+- Routes must be unique and start with `/`; duplicates fail at startup. The
+  collision rule (append `-<index>`) exists to prevent this.
+- `FlutterDeckCodeHighlight.highlightedLines` are **0-indexed**.
+- Set `preloadImages` on every image slide so images don't pop in mid-talk.
+- Generated slides omit an explicit `Key` (matching flutter_deck's Mason brick
+  and example). A freshly `flutter create`d project's default lints flag this
+  via `use_key_in_widget_constructors`; flutter_deck's own example disables
+  that rule in `analysis_options.yaml`. If the target project has it enabled,
+  either disable the rule or add `Key? key` params.
+- This skill does not set up the app or themes — use
+  flutter-deck-presentation-setup and flutter-deck-theming for those.

--- a/skills/flutter-deck-author/SKILL.md
+++ b/skills/flutter-deck-author/SKILL.md
@@ -82,6 +82,11 @@ Pick the factory from the **shape** of the segment's content:
 | Empty / unrecognized                            | `FlutterDeckSlide.blank`                                          |
 
 Notes:
+- **Precedence:** evaluate the rows top-to-bottom and use the first that
+  matches; the bottom two rows are fallbacks. A `<!-- slide: -->` directive
+  always overrides the heuristic. If a segment genuinely matches two specific
+  rows (e.g. text with both an image and a fenced code block), prefer `split`
+  or add an explicit `<!-- slide: -->`.
 - A bulleted content slide sets `header: FlutterDeckHeaderConfiguration(title:
   <heading>)` so the section title shows above the bullets.
 - Code slides: language comes from the fence info string (```` ```dart ````);
@@ -111,6 +116,9 @@ document. Place a directive inside the slide's segment.
   (`Slide100`). Empty → `Slide<index>`.
 - **File name:** snake_case of the class name (`WhySlidesAsCodeSlide` →
   `why_slides_as_code_slide.dart`; `Slide100` → `slide100.dart`).
+- **Barrel order:** order the `export` statements alphabetically (Dart's
+  `directives_ordering` lint expects this); the `FlutterDeckApp.slides` list,
+  by contrast, follows outline order.
 
 ## Worked Example
 


### PR DESCRIPTION
## What

Adds a sixth agent skill, **`flutter-deck-author`**, that turns a Markdown outline into idiomatic `flutter_deck` slide files.

The existing five skills are all *reference* skills (they teach how to use the API). None help a user go from a topic/outline to a finished deck — the actual authoring bottleneck. This skill closes that gap: the author writes content in Markdown, the agent emits one Dart file per slide.

It is **content-only** and composes with the existing skills:
- Defers app scaffolding to `flutter-deck-presentation-setup`.
- Refers to `flutter-deck-slides` / `flutter-deck-theming` for factory and styling detail.
- Does **not** add the dependency, wire `FlutterDeckApp`, or define themes.

## How it works

- **Segments** Markdown into slides (`#` → opening title, `---` hard break, else each `##`).
- **Maps** each block to a built-in factory by content shape (blockquote → `quote`, short stat → `bigFact`, fenced code → `blank` + `FlutterDeckCodeHighlight`, image → `image`, text+media → `split`, heading + bullets → `blank` + `FlutterDeckBulletList`), with a stated top-to-bottom precedence rule.
- **Override directives** (invisible HTML comments): `<!-- slide: <factory> -->`, `<!-- steps: reveal -->`, `<!-- notes: … -->`, `<!-- route: /custom -->`.
- **Derives** route, class name, file name, and nav-drawer `title:` from each heading (with a digit-leading fallback, e.g. `100%` → `Slide100`, `/100`).
- **Wires** the `lib/slides/` barrel (alphabetical) and the `FlutterDeckApp.slides` list (outline order).

Registered in `README.md` and the docs site (`doc/website/source/ai/agent-skills.md`).

## Verification

- The skill's worked example was built into a throwaway deck and passes `flutter analyze` + `flutter build web`; the two embedded slide examples are byte-for-byte identical to that verified fixture.
- Every API used was cross-checked against the package source.
- A **cold-follow test** — a fresh agent given *only* this `SKILL.md` and the worked-example outline — reproduced an identical file set: same routes, class names, factory choices, `steps`, and barrel (no factory/route/class divergence).

## Notes

- `.gitignore` now ignores `docs/superpowers/` (local design/plan scratch).
- No Dart source in the package changed — docs/skill only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
